### PR TITLE
Reduce vertical spacing between planner tasks

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -386,7 +386,7 @@ function PlannerApp(){
               {Array.from({length: Math.max(0,...tasksToShow.map(t=>typeof t.row==='number'?t.row:0))+1}, (_,row)=>row).map(row=>(
                 <div key={row} className="relative border-b border-slate-100" style={{gridColumn:`1 / -1`}}>
                   <div style={{display:'grid', gridTemplateColumns:`repeat(${weeks.length}, ${colWidthPx}px)`}}>
-                    {weeks.map((_,i)=><div key={i} className={(i%2===0?"border-slate-50":"border-slate-100")+" h-12 border-r"} />)}
+                    {weeks.map((_,i)=><div key={i} className={(i%2===0?"border-slate-50":"border-slate-100")+" h-10 border-r"} />)}
                   </div>
                   {tasksToShow.filter(t=>(t.row??0)===row).map(t=>{
                     const {startIdx,span}=taskToGrid(t);
@@ -396,8 +396,8 @@ function PlannerApp(){
                     if(isDragging){ if(drag.type==='move') leftAdj=leftPx+(drag.dx||0); if(drag.type==='right') widthAdj=Math.max(colWidthPx,widthPx+(drag.dx||0)); if(drag.type==='left'){ const w=Math.max(colWidthPx,widthPx-(drag.dx||0)); leftAdj=leftPx+(drag.dx||0); widthAdj=w; } }
                     const isNarrow=widthAdj<64; const noteCount=Array.isArray(t.notes)?t.notes.length:0;
                     return (
-                      <div key={t.id} className="pointer-events-none absolute left-0 top-0 h-12 w-full">
-                        <div className="pointer-events-auto absolute top-1 h-10 select-none rounded-xl shadow-sm group" style={{left:leftAdj,width:widthAdj,backgroundColor:t.color}}>
+                      <div key={t.id} className="pointer-events-none absolute left-0 top-0 h-10 w-full">
+                        <div className="pointer-events-auto absolute top-1 h-8 select-none rounded-xl shadow-sm group" style={{left:leftAdj,width:widthAdj,backgroundColor:t.color}}>
                           {noteCount>0 && <span className="absolute -top-1 -left-1 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full border border-white bg-slate-900 px-1 text-[10px] font-semibold text-white">{noteCount}</span>}
                           <div className="flex h-full items-center gap-1 pl-1 pr-2 text-[11px] text-slate-700">
                             {!isNarrow && <span className="inline-block h-2 w-2 rounded" style={{backgroundColor:t.color}}/>}

--- a/docs/index.html
+++ b/docs/index.html
@@ -386,7 +386,7 @@ function PlannerApp(){
               {Array.from({length: Math.max(0,...tasksToShow.map(t=>typeof t.row==='number'?t.row:0))+1}, (_,row)=>row).map(row=>(
                 <div key={row} className="relative border-b border-slate-100" style={{gridColumn:`1 / -1`}}>
                   <div style={{display:'grid', gridTemplateColumns:`repeat(${weeks.length}, ${colWidthPx}px)`}}>
-                    {weeks.map((_,i)=><div key={i} className={(i%2===0?"border-slate-50":"border-slate-100")+" h-12 border-r"} />)}
+                    {weeks.map((_,i)=><div key={i} className={(i%2===0?"border-slate-50":"border-slate-100")+" h-10 border-r"} />)}
                   </div>
                   {tasksToShow.filter(t=>(t.row??0)===row).map(t=>{
                     const {startIdx,span}=taskToGrid(t);
@@ -396,8 +396,8 @@ function PlannerApp(){
                     if(isDragging){ if(drag.type==='move') leftAdj=leftPx+(drag.dx||0); if(drag.type==='right') widthAdj=Math.max(colWidthPx,widthPx+(drag.dx||0)); if(drag.type==='left'){ const w=Math.max(colWidthPx,widthPx-(drag.dx||0)); leftAdj=leftPx+(drag.dx||0); widthAdj=w; } }
                     const isNarrow=widthAdj<64; const noteCount=Array.isArray(t.notes)?t.notes.length:0;
                     return (
-                      <div key={t.id} className="pointer-events-none absolute left-0 top-0 h-12 w-full">
-                        <div className="pointer-events-auto absolute top-1 h-10 select-none rounded-xl shadow-sm group" style={{left:leftAdj,width:widthAdj,backgroundColor:t.color}}>
+                      <div key={t.id} className="pointer-events-none absolute left-0 top-0 h-10 w-full">
+                        <div className="pointer-events-auto absolute top-1 h-8 select-none rounded-xl shadow-sm group" style={{left:leftAdj,width:widthAdj,backgroundColor:t.color}}>
                           {noteCount>0 && <span className="absolute -top-1 -left-1 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full border border-white bg-slate-900 px-1 text-[10px] font-semibold text-white">{noteCount}</span>}
                           <div className="flex h-full items-center gap-1 pl-1 pr-2 text-[11px] text-slate-700">
                             {!isNarrow && <span className="inline-block h-2 w-2 rounded" style={{backgroundColor:t.color}}/>}


### PR DESCRIPTION
## Summary
- tighten weekly grid rows to `h-10` for a more compact schedule
- shrink task blocks to `h-8` so tasks sit closer together

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a057517b248332b9ab6528e0b69cf1