### PR TITLE
feat: add expandable sub-task lanes with font scaling

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -52,6 +52,8 @@ const MS_DAY = 24*60*60*1000;
 const COL_W = 44;                     // largeur d’une semaine (px)
 const ROW_H = 26;                     // hauteur d’une ligne (px)
 const ROW_GAP = 2;                    // petit padding vertical dans une ligne
+const SUB_ROW_H = 22;                 // hauteur d'une voie dans la sous-frise
+const SUB_ROW_GAP = 2;                // marge interne des sous-barres
 const fmtMonthYear = new Intl.DateTimeFormat("fr-FR",{ month:"long", year:"numeric" });
 const fmtDM = new Intl.DateTimeFormat("fr-FR",{ day:"numeric", month:"short" });
 
@@ -121,6 +123,12 @@ function packLanes(children, weeks){
 
   const lanesCount = Math.max(1, lanes.length || 1);
   return { lanesCount, placed };
+}
+
+function fontPxFor(width, title){
+  const charW = 0.6;
+  const px = Math.floor(width / (charW * Math.max(1, title.length)));
+  return Math.max(8, Math.min(11, px));
 }
 
 /* ---------- Composant ---------- */
@@ -218,7 +226,6 @@ function PlannerApp(){
       for(const p of rowTasks){
         if(!p.expanded) continue;
         const children = tasks.filter(t => t.parentId===p.id);
-        if(children.length===0) continue;
         const { lanesCount } = packLanes(children, weeks);
         rows.push({ type:'sub', parentId:p.id, lanesCount });
       }
@@ -230,6 +237,7 @@ function PlannerApp(){
   const [drag,setDrag] = useState(null); // {taskId,type,startX,startY,dx,dy}
   const subZonesRef = useRef({});        // parentId -> DOMRect
   const containerRef = useRef(null);
+  const scrollRef = useRef(null);
 
   // recalcul des bounding boxes des sous-frises après rendu
   useEffect(()=>{
@@ -254,6 +262,22 @@ function PlannerApp(){
     };
   }, [layoutRows, tasks]);
 
+  function calcRowFromY(clientY){
+    if(!scrollRef.current) return 0;
+    const rect = scrollRef.current.getBoundingClientRect();
+    const y = clientY - rect.top + scrollRef.current.scrollTop;
+    let acc = 0, row = 0;
+    for(const r of layoutRows){
+      const h = r.type==='main' ? ROW_H : r.lanesCount * SUB_ROW_H;
+      if(r.type==='main'){
+        if(y < acc + h/2) return row;
+        row++;
+      }
+      acc += h;
+    }
+    return row;
+  }
+
   useEffect(()=>{
     if(!drag) return;
     function onMove(e){ setDrag(d => d ? {...d, dx:e.clientX - d.startX, dy:e.clientY - d.startY } : d); }
@@ -264,16 +288,20 @@ function PlannerApp(){
         const idx=prev.findIndex(t=>t.id===d.taskId); if(idx<0) return prev;
         const t=prev[idx];
 
-        // 1) déplacement horizontal (dates)
+        // 1) déplacement horizontal / resize
         const deltaWeeks = Math.round((d.dx||0)/COL_W);
-        const ns = addWeeksISO(t.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
-        const ne = addWeeksISO(t.endISO,   deltaWeeks, TIMELINE_START, TIMELINE_END);
+        let ns = t.startISO;
+        let ne = t.endISO;
+        if(d.type === 'move'){
+          ns = addWeeksISO(t.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
+          ne = addWeeksISO(t.endISO,   deltaWeeks, TIMELINE_START, TIMELINE_END);
+        }else if(d.type === 'left'){
+          ns = addWeeksISO(t.startISO, deltaWeeks, TIMELINE_START, new Date(t.endISO));
+        }else if(d.type === 'right'){
+          ne = addWeeksISO(t.endISO, deltaWeeks, new Date(t.startISO), TIMELINE_END);
+        }
 
-        // 2) changement de rang (haut/bas) – uniquement pour top-level
-        const deltaRows = Math.round((d.dy||0)/ROW_H);
-        const newTopRow = Math.max(0, (t.row||0) + deltaRows);
-
-        // 3) test : est-ce que la souris est lâchée au dessus d’une sous-frise ?
+        // 2) test : est-ce que la souris est lâchée au dessus d’une sous-frise ?
         let targetParentId = null;
         for(const [pid, rect] of Object.entries(subZonesRef.current)){
           if(dropX>=rect.left && dropX<=rect.right && dropY>=rect.top && dropY<=rect.bottom){
@@ -285,10 +313,13 @@ function PlannerApp(){
         const copy = prev.slice();
         // Si on drop dans une sous-frise : rendre l’élément enfant du parent
         if(targetParentId && targetParentId!==t.id){
-          copy[idx] = { ...t, parentId: targetParentId, startISO: ns, endISO: ne };
+          const next = { ...t, parentId: targetParentId, startISO: ns, endISO: ne };
+          delete next.row;
+          copy[idx] = next;
           return copy;
         }
         // Sinon, on reste (ou on redevient) top-level
+        const newTopRow = calcRowFromY(dropY);
         copy[idx] = { ...t, parentId: null, row: newTopRow, startISO: ns, endISO: ne };
         return copy;
       });
@@ -382,17 +413,18 @@ function PlannerApp(){
     </div>
   );
 
-  function TaskBar({t, draggable=true, onDoubleClick, labelSuffix=""}){
+  function TaskBar({t, draggable=true, onDoubleClick, labelSuffix="", rowHeight=ROW_H, gap=ROW_GAP}){
     const g = taskGridInfo(t, weeks);
     const isNarrow = g.width < 64;
+    const fontPx = fontPxFor(g.width, t.title + labelSuffix);
     return (
-      <div className="pointer-events-none absolute left-0 top-0 w-full" style={{height: ROW_H}}>
+      <div className="pointer-events-none absolute left-0 top-0 w-full" style={{height: rowHeight}}>
         <div
           className="pointer-events-auto absolute select-none rounded-lg shadow-sm group"
-          style={{ left:g.left, width:g.width, top:ROW_GAP/2, height:ROW_H-ROW_GAP, backgroundColor:t.color }}
+          style={{ left:g.left, width:g.width, top:gap/2, height:rowHeight-gap, backgroundColor:t.color }}
           onDoubleClick={onDoubleClick}
         >
-          <div className="flex h-full items-center gap-1 pl-1 pr-2 text-[11px] text-slate-700">
+          <div className="flex h-full items-center gap-1 pl-1 pr-2 text-slate-700" style={{fontSize:fontPx}}>
             {!isNarrow && <span className="inline-block h-2 w-2 rounded" style={{backgroundColor:t.color}} />}
             <span className="truncate min-w-0 font-medium" title={`${t.title}${labelSuffix} — ${t.startISO} → ${t.endISO}`}>{t.title}{labelSuffix}</span>
             <div className="ml-auto hidden items-center gap-1 group-hover:flex">
@@ -472,7 +504,7 @@ function PlannerApp(){
         <div ref={containerRef} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm h-[82vh] max-h-[82vh] flex flex-col min-h-0">
           {header}
 
-          <div className="min-h-0 flex-1 overflow-auto">
+          <div className="min-h-0 flex-1 overflow-auto" ref={scrollRef}>
             {/* Lignes dynamiques */}
             {layoutRows.map((row,i)=>{
               if(row.type==='main'){
@@ -494,24 +526,24 @@ function PlannerApp(){
                 );
               }
 
-              // Sous-frise (un seul bloc, hauteur = lanes * ROW_H)
+              // Sous-frise (un seul bloc, hauteur = lanes * SUB_ROW_H)
               const parent = tasks.find(t=>t.id===row.parentId);
+              if(!parent) return null;
               const children = tasks.filter(t=>t.parentId===row.parentId);
-              if(!parent || children.length===0) return null;
               const packed = packLanes(children, weeks);
 
               return (
                 <div
                   key={`sub-${i}`}
                   className="relative border-b border-slate-100 bg-white"
-                  style={{ display:'grid', gridTemplateColumns:gridCols, height: packed.lanesCount * ROW_H }}
+                  style={{ display:'grid', gridTemplateColumns:gridCols, height: packed.lanesCount * SUB_ROW_H }}
                   data-subzone="1"
                   data-parentid={row.parentId}
                   title="Sous-frise : déposez une tâche ici pour l’ajouter"
                 >
                   {/* fond */}
                   {Array.from({length: packed.lanesCount}).map((_,laneIdx)=>(
-                    <div key={laneIdx} className="absolute left-0 right-0" style={{ top: laneIdx*ROW_H, height: ROW_H }}>
+                    <div key={laneIdx} className="absolute left-0 right-0" style={{ top: laneIdx*SUB_ROW_H, height: SUB_ROW_H }}>
                       <div style={{display:'grid', gridTemplateColumns:gridCols, height:'100%'}}>
                         {weeks.map((_,ci)=><div key={ci} className={(ci%2===0?"border-slate-50":"border-slate-100")+" border-r"} />)}
                       </div>
@@ -519,8 +551,8 @@ function PlannerApp(){
                   ))}
                   {/* sous-tâches (empilées par lane) */}
                   {packed.placed.map(p=>(
-                    <div key={p.t.id} className="absolute left-0 top-0 w-full" style={{ height: ROW_H, transform:`translateY(${p.lane*ROW_H}px)` }}>
-                      <TaskBar t={p.t} draggable={true} onDoubleClick={()=>{ /* rien ici */ }} />
+                    <div key={p.t.id} className="absolute left-0 top-0 w-full" style={{ height: SUB_ROW_H, transform:`translateY(${p.lane*SUB_ROW_H}px)` }}>
+                      <TaskBar t={p.t} draggable={true} onDoubleClick={()=>{}} rowHeight={SUB_ROW_H} gap={SUB_ROW_GAP} />
                     </div>
                   ))}
                 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,6 +52,8 @@ const MS_DAY = 24*60*60*1000;
 const COL_W = 44;                     // largeur d’une semaine (px)
 const ROW_H = 26;                     // hauteur d’une ligne (px)
 const ROW_GAP = 2;                    // petit padding vertical dans une ligne
+const SUB_ROW_H = 22;                 // hauteur d'une voie dans la sous-frise
+const SUB_ROW_GAP = 2;                // marge interne des sous-barres
 const fmtMonthYear = new Intl.DateTimeFormat("fr-FR",{ month:"long", year:"numeric" });
 const fmtDM = new Intl.DateTimeFormat("fr-FR",{ day:"numeric", month:"short" });
 
@@ -121,6 +123,12 @@ function packLanes(children, weeks){
 
   const lanesCount = Math.max(1, lanes.length || 1);
   return { lanesCount, placed };
+}
+
+function fontPxFor(width, title){
+  const charW = 0.6;
+  const px = Math.floor(width / (charW * Math.max(1, title.length)));
+  return Math.max(8, Math.min(11, px));
 }
 
 /* ---------- Composant ---------- */
@@ -218,7 +226,6 @@ function PlannerApp(){
       for(const p of rowTasks){
         if(!p.expanded) continue;
         const children = tasks.filter(t => t.parentId===p.id);
-        if(children.length===0) continue;
         const { lanesCount } = packLanes(children, weeks);
         rows.push({ type:'sub', parentId:p.id, lanesCount });
       }
@@ -230,6 +237,7 @@ function PlannerApp(){
   const [drag,setDrag] = useState(null); // {taskId,type,startX,startY,dx,dy}
   const subZonesRef = useRef({});        // parentId -> DOMRect
   const containerRef = useRef(null);
+  const scrollRef = useRef(null);
 
   // recalcul des bounding boxes des sous-frises après rendu
   useEffect(()=>{
@@ -254,6 +262,22 @@ function PlannerApp(){
     };
   }, [layoutRows, tasks]);
 
+  function calcRowFromY(clientY){
+    if(!scrollRef.current) return 0;
+    const rect = scrollRef.current.getBoundingClientRect();
+    const y = clientY - rect.top + scrollRef.current.scrollTop;
+    let acc = 0, row = 0;
+    for(const r of layoutRows){
+      const h = r.type==='main' ? ROW_H : r.lanesCount * SUB_ROW_H;
+      if(r.type==='main'){
+        if(y < acc + h/2) return row;
+        row++;
+      }
+      acc += h;
+    }
+    return row;
+  }
+
   useEffect(()=>{
     if(!drag) return;
     function onMove(e){ setDrag(d => d ? {...d, dx:e.clientX - d.startX, dy:e.clientY - d.startY } : d); }
@@ -264,16 +288,20 @@ function PlannerApp(){
         const idx=prev.findIndex(t=>t.id===d.taskId); if(idx<0) return prev;
         const t=prev[idx];
 
-        // 1) déplacement horizontal (dates)
+        // 1) déplacement horizontal / resize
         const deltaWeeks = Math.round((d.dx||0)/COL_W);
-        const ns = addWeeksISO(t.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
-        const ne = addWeeksISO(t.endISO,   deltaWeeks, TIMELINE_START, TIMELINE_END);
+        let ns = t.startISO;
+        let ne = t.endISO;
+        if(d.type === 'move'){
+          ns = addWeeksISO(t.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
+          ne = addWeeksISO(t.endISO,   deltaWeeks, TIMELINE_START, TIMELINE_END);
+        }else if(d.type === 'left'){
+          ns = addWeeksISO(t.startISO, deltaWeeks, TIMELINE_START, new Date(t.endISO));
+        }else if(d.type === 'right'){
+          ne = addWeeksISO(t.endISO, deltaWeeks, new Date(t.startISO), TIMELINE_END);
+        }
 
-        // 2) changement de rang (haut/bas) – uniquement pour top-level
-        const deltaRows = Math.round((d.dy||0)/ROW_H);
-        const newTopRow = Math.max(0, (t.row||0) + deltaRows);
-
-        // 3) test : est-ce que la souris est lâchée au dessus d’une sous-frise ?
+        // 2) test : est-ce que la souris est lâchée au dessus d’une sous-frise ?
         let targetParentId = null;
         for(const [pid, rect] of Object.entries(subZonesRef.current)){
           if(dropX>=rect.left && dropX<=rect.right && dropY>=rect.top && dropY<=rect.bottom){
@@ -285,10 +313,13 @@ function PlannerApp(){
         const copy = prev.slice();
         // Si on drop dans une sous-frise : rendre l’élément enfant du parent
         if(targetParentId && targetParentId!==t.id){
-          copy[idx] = { ...t, parentId: targetParentId, startISO: ns, endISO: ne };
+          const next = { ...t, parentId: targetParentId, startISO: ns, endISO: ne };
+          delete next.row;
+          copy[idx] = next;
           return copy;
         }
         // Sinon, on reste (ou on redevient) top-level
+        const newTopRow = calcRowFromY(dropY);
         copy[idx] = { ...t, parentId: null, row: newTopRow, startISO: ns, endISO: ne };
         return copy;
       });
@@ -382,17 +413,18 @@ function PlannerApp(){
     </div>
   );
 
-  function TaskBar({t, draggable=true, onDoubleClick, labelSuffix=""}){
+  function TaskBar({t, draggable=true, onDoubleClick, labelSuffix="", rowHeight=ROW_H, gap=ROW_GAP}){
     const g = taskGridInfo(t, weeks);
     const isNarrow = g.width < 64;
+    const fontPx = fontPxFor(g.width, t.title + labelSuffix);
     return (
-      <div className="pointer-events-none absolute left-0 top-0 w-full" style={{height: ROW_H}}>
+      <div className="pointer-events-none absolute left-0 top-0 w-full" style={{height: rowHeight}}>
         <div
           className="pointer-events-auto absolute select-none rounded-lg shadow-sm group"
-          style={{ left:g.left, width:g.width, top:ROW_GAP/2, height:ROW_H-ROW_GAP, backgroundColor:t.color }}
+          style={{ left:g.left, width:g.width, top:gap/2, height:rowHeight-gap, backgroundColor:t.color }}
           onDoubleClick={onDoubleClick}
         >
-          <div className="flex h-full items-center gap-1 pl-1 pr-2 text-[11px] text-slate-700">
+          <div className="flex h-full items-center gap-1 pl-1 pr-2 text-slate-700" style={{fontSize:fontPx}}>
             {!isNarrow && <span className="inline-block h-2 w-2 rounded" style={{backgroundColor:t.color}} />}
             <span className="truncate min-w-0 font-medium" title={`${t.title}${labelSuffix} — ${t.startISO} → ${t.endISO}`}>{t.title}{labelSuffix}</span>
             <div className="ml-auto hidden items-center gap-1 group-hover:flex">
@@ -472,7 +504,7 @@ function PlannerApp(){
         <div ref={containerRef} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm h-[82vh] max-h-[82vh] flex flex-col min-h-0">
           {header}
 
-          <div className="min-h-0 flex-1 overflow-auto">
+          <div className="min-h-0 flex-1 overflow-auto" ref={scrollRef}>
             {/* Lignes dynamiques */}
             {layoutRows.map((row,i)=>{
               if(row.type==='main'){
@@ -494,24 +526,24 @@ function PlannerApp(){
                 );
               }
 
-              // Sous-frise (un seul bloc, hauteur = lanes * ROW_H)
+              // Sous-frise (un seul bloc, hauteur = lanes * SUB_ROW_H)
               const parent = tasks.find(t=>t.id===row.parentId);
+              if(!parent) return null;
               const children = tasks.filter(t=>t.parentId===row.parentId);
-              if(!parent || children.length===0) return null;
               const packed = packLanes(children, weeks);
 
               return (
                 <div
                   key={`sub-${i}`}
                   className="relative border-b border-slate-100 bg-white"
-                  style={{ display:'grid', gridTemplateColumns:gridCols, height: packed.lanesCount * ROW_H }}
+                  style={{ display:'grid', gridTemplateColumns:gridCols, height: packed.lanesCount * SUB_ROW_H }}
                   data-subzone="1"
                   data-parentid={row.parentId}
                   title="Sous-frise : déposez une tâche ici pour l’ajouter"
                 >
                   {/* fond */}
                   {Array.from({length: packed.lanesCount}).map((_,laneIdx)=>(
-                    <div key={laneIdx} className="absolute left-0 right-0" style={{ top: laneIdx*ROW_H, height: ROW_H }}>
+                    <div key={laneIdx} className="absolute left-0 right-0" style={{ top: laneIdx*SUB_ROW_H, height: SUB_ROW_H }}>
                       <div style={{display:'grid', gridTemplateColumns:gridCols, height:'100%'}}>
                         {weeks.map((_,ci)=><div key={ci} className={(ci%2===0?"border-slate-50":"border-slate-100")+" border-r"} />)}
                       </div>
@@ -519,8 +551,8 @@ function PlannerApp(){
                   ))}
                   {/* sous-tâches (empilées par lane) */}
                   {packed.placed.map(p=>(
-                    <div key={p.t.id} className="absolute left-0 top-0 w-full" style={{ height: ROW_H, transform:`translateY(${p.lane*ROW_H}px)` }}>
-                      <TaskBar t={p.t} draggable={true} onDoubleClick={()=>{ /* rien ici */ }} />
+                    <div key={p.t.id} className="absolute left-0 top-0 w-full" style={{ height: SUB_ROW_H, transform:`translateY(${p.lane*SUB_ROW_H}px)` }}>
+                      <TaskBar t={p.t} draggable={true} onDoubleClick={()=>{}} rowHeight={SUB_ROW_H} gap={SUB_ROW_GAP} />
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- render expandable sub-frises even without children so tasks can be dropped inline
- stack sub-tasks on 22px lanes and resize labels according to bar width
- recalc top-level row from drop position and keep resize/move interactions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d6728f1c83328da0c4de02d8f671