### PR TITLE
feat(ui): move category legend to bottom, enable wrap, remove global horizontal scroll

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -598,7 +598,7 @@ function PlannerApp(){
   }
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
+    <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <div className="flex flex-col">
         {/* Top bar */}
@@ -611,25 +611,6 @@ function PlannerApp(){
           </button>
           <h1 className="text-lg font-semibold tracking-tight">Planning (sept. 2025 → fév. 2026)</h1>
         </div>
-
-        {/* Filtres catégories */}
-        {categories.length>0 && (
-          <div className="mb-4 overflow-x-auto">
-            <div className="flex items-center gap-2 whitespace-nowrap">
-              {categories.map(c=>(
-                <div key={c.id} className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1 text-sm shadow-sm">
-                  <input type="checkbox" checked={c.enabled !== false} onChange={()=>toggleCategory(c.id)} className="h-4 w-4 accent-slate-900" />
-                  <label className="relative" title={c.color}>
-                    <input type="color" value={c.color} onChange={(e)=>updateCategoryColor(c.id, e.target.value)} className="absolute inset-0 h-3 w-3 opacity-0 cursor-pointer" />
-                    <span className="inline-block h-3 w-3 rounded-full" style={{backgroundColor:c.color}} />
-                  </label>
-                  <span className="font-medium">{c.name}</span>
-                  <span className="text-xs text-slate-500">{c.color}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
 
         {/* Gantt */}
         <div ref={containerRef} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm h-[82vh] max-h-[82vh] flex flex-col min-h-0">
@@ -723,6 +704,24 @@ function PlannerApp(){
         </aside>
 
         </div>
+
+      {categories.length>0 && (
+        <footer className="w-full max-w-[1400px] mx-auto px-4 pb-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {categories.map(c=>(
+              <div key={c.id} className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1 text-sm shadow-sm">
+                <input type="checkbox" checked={c.enabled !== false} onChange={()=>toggleCategory(c.id)} className="h-4 w-4 accent-slate-900" />
+                <label className="relative" title={c.color}>
+                  <input type="color" value={c.color} onChange={(e)=>updateCategoryColor(c.id, e.target.value)} className="absolute inset-0 h-3 w-3 opacity-0 cursor-pointer" />
+                  <span className="inline-block h-3 w-3 rounded-full" style={{backgroundColor:c.color}} />
+                </label>
+                <span className="font-medium">{c.name}</span>
+                <span className="text-xs text-slate-500">{c.color}</span>
+              </div>
+            ))}
+          </div>
+        </footer>
+      )}
 
         {/* Panneau latéral (ajout) */}
         {panelOpen && (

--- a/docs/index.html
+++ b/docs/index.html
@@ -598,7 +598,7 @@ function PlannerApp(){
   }
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
+    <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <div className="flex flex-col">
         {/* Top bar */}
@@ -611,25 +611,6 @@ function PlannerApp(){
           </button>
           <h1 className="text-lg font-semibold tracking-tight">Planning (sept. 2025 → fév. 2026)</h1>
         </div>
-
-        {/* Filtres catégories */}
-        {categories.length>0 && (
-          <div className="mb-4 overflow-x-auto">
-            <div className="flex items-center gap-2 whitespace-nowrap">
-              {categories.map(c=>(
-                <div key={c.id} className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1 text-sm shadow-sm">
-                  <input type="checkbox" checked={c.enabled !== false} onChange={()=>toggleCategory(c.id)} className="h-4 w-4 accent-slate-900" />
-                  <label className="relative" title={c.color}>
-                    <input type="color" value={c.color} onChange={(e)=>updateCategoryColor(c.id, e.target.value)} className="absolute inset-0 h-3 w-3 opacity-0 cursor-pointer" />
-                    <span className="inline-block h-3 w-3 rounded-full" style={{backgroundColor:c.color}} />
-                  </label>
-                  <span className="font-medium">{c.name}</span>
-                  <span className="text-xs text-slate-500">{c.color}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
 
         {/* Gantt */}
         <div ref={containerRef} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm h-[82vh] max-h-[82vh] flex flex-col min-h-0">
@@ -723,6 +704,24 @@ function PlannerApp(){
         </aside>
 
         </div>
+
+      {categories.length>0 && (
+        <footer className="w-full max-w-[1400px] mx-auto px-4 pb-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {categories.map(c=>(
+              <div key={c.id} className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1 text-sm shadow-sm">
+                <input type="checkbox" checked={c.enabled !== false} onChange={()=>toggleCategory(c.id)} className="h-4 w-4 accent-slate-900" />
+                <label className="relative" title={c.color}>
+                  <input type="color" value={c.color} onChange={(e)=>updateCategoryColor(c.id, e.target.value)} className="absolute inset-0 h-3 w-3 opacity-0 cursor-pointer" />
+                  <span className="inline-block h-3 w-3 rounded-full" style={{backgroundColor:c.color}} />
+                </label>
+                <span className="font-medium">{c.name}</span>
+                <span className="text-xs text-slate-500">{c.color}</span>
+              </div>
+            ))}
+          </div>
+        </footer>
+      )}
 
         {/* Panneau latéral (ajout) */}
         {panelOpen && (


### PR DESCRIPTION
## Summary
- move category legend below timeline in index and 404 pages
- allow multi-line wrapping for category chips and hide global horizontal overflow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22958c61883328ffe7939fc4caf4b