### PR TITLE
Move task actions to left sidebar on selection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -555,7 +555,7 @@ function PlannerApp(){
       <div className="pointer-events-none absolute left-0 top-0 w-full" style={{height: rowHeight}}>
         <div
           ref={barRef}
-          className={"pointer-events-auto absolute select-none rounded-lg shadow-sm group task-bar touch-none z-10" + (isNarrow ? " hide-bullet" : "")}
+          className={"pointer-events-auto absolute select-none rounded-lg shadow-sm task-bar touch-none z-10" + (isNarrow ? " hide-bullet" : "")}
           style={{ left:g.left, width:g.width, top:gap/2, height:rowHeight-gap, backgroundColor:t.color, '--task-font': fontPx }}
           onDoubleClick={(e)=>{ e.preventDefault(); e.stopPropagation(); lastWasDblClickRef.current = true; setTimeout(()=>{ lastWasDblClickRef.current = false; },0); onToggle && onToggle(); }}
           onClick={(e)=>{ if(dragHappenedRef.current){ dragHappenedRef.current=false; return; } if(lastWasDblClickRef.current){ lastWasDblClickRef.current=false; return; } setSelectedTaskId(t.id); }}
@@ -572,22 +572,6 @@ function PlannerApp(){
             )}
             <span className="bullet inline-block h-2 w-2 rounded" style={{backgroundColor:t.color}} />
             <span className="truncate min-w-0 font-medium" title={`${t.title} — ${t.startISO} → ${t.endISO}`}>{t.title}</span>
-            <div className="ml-auto hidden items-center gap-1 group-hover:flex">
-              {t.parentId && (
-                <button
-                  data-no-drag
-                  className="rounded border border-slate-300 bg-white px-1 text-[10px] hover:bg-slate-50"
-                  title="Retirer de la sous-frise"
-                  onClick={(e)=>{e.stopPropagation(); setTasks(prev=>prev.map(x=> x.id===t.id ? {...x,parentId:null} : x));}}
-                >↶</button>
-              )}
-              <button
-                data-no-drag
-                onClick={(e)=>{e.stopPropagation(); removeTask(t.id);}}
-                className="rounded border border-red-200 bg-white px-1 text-[10px] text-red-700 hover:bg-red-50"
-                title="Supprimer"
-              >🗑</button>
-            </div>
           </div>
 
           {draggable && (
@@ -627,10 +611,27 @@ function PlannerApp(){
         </div>
 
         {/* Gantt */}
-        <div ref={containerRef} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm h-[82vh] max-h-[82vh] flex flex-col min-h-0">
-          {header}
+        <div className="relative">
+          {selectedTask && (
+            <div className="absolute top-0 left-0 -translate-x-full flex flex-col gap-1 p-1">
+              {selectedTask.parentId && (
+                <button
+                  className="rounded border border-slate-300 bg-white px-1 text-[10px] hover:bg-slate-50"
+                  title="Retirer de la sous-frise"
+                  onClick={()=>setTasks(prev=>prev.map(x=> x.id===selectedTask.id ? {...x,parentId:null} : x))}
+                >↶</button>
+              )}
+              <button
+                className="rounded border border-red-200 bg-white px-1 text-[10px] text-red-700 hover:bg-red-50"
+                title="Supprimer"
+                onClick={()=>{ removeTask(selectedTask.id); setSelectedTaskId(null); }}
+              >🗑</button>
+            </div>
+          )}
+          <div ref={containerRef} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm h-[82vh] max-h-[82vh] flex flex-col min-h-0">
+            {header}
 
-          <div className="min-h-0 flex-1 overflow-auto" ref={scrollRef}>
+            <div className="min-h-0 flex-1 overflow-auto" ref={scrollRef}>
             {/* Lignes dynamiques */}
             {layoutRows.map((row,i)=>{
               if(row.type==='main'){


### PR DESCRIPTION
## Summary
- show task actions in a fixed left panel when a task is clicked
- remove hover-based action controls from task bars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2353da80c8332940f5044a297fa23