### PR TITLE
Fix missing closing div in planner pages

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -812,6 +812,7 @@ function PlannerApp(){
           </div>
         )}
       </div>
+    </div>
   );
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -812,6 +812,7 @@ function PlannerApp(){
           </div>
         )}
       </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- close remaining outer `<div>` tags in both `index.html` and `404.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2393578288332b629fde21ceeb294