### PR TITLE
fix: remove extra closing div

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -814,7 +814,6 @@ function PlannerApp(){
             </aside>
           </div>
         )}
-      </div>
     </div>
   );
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -814,7 +814,6 @@ function PlannerApp(){
             </aside>
           </div>
         )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove stray closing div to keep JSX tree valid in PlannerApp

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a24108f2ac8332a156aaaa2e846e64