### PR TITLE
Move note panel and block actions to the right

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -601,10 +601,10 @@ function PlannerApp(){
 
   return (
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
-      <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'360px 1fr',gap:'24px'}}>
+      <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <aside
-          className="sticky h-[82vh] overflow-y-auto border-r border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
-          style={{ top: headerHeight + 16 }}
+          className="sticky h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
+          style={{ top: headerHeight + 16, gridColumn:'2' }}
           aria-labelledby="notes-title"
         >
           <div id="notes-title" className="border-b border-slate-200 px-4 py-3 font-medium text-slate-700">{selectedTask ? selectedTask.title : 'Notes'}</div>
@@ -633,7 +633,7 @@ function PlannerApp(){
             )}
           </div>
         </aside>
-        <div className="flex flex-col">
+        <div className="flex flex-col" style={{gridColumn:'1'}}>
         {/* Top bar */}
         <div className="mb-4 flex items-center justify-between">
           <button
@@ -648,7 +648,7 @@ function PlannerApp(){
         {/* Gantt */}
         <div className="relative">
           {selectedTask && (
-            <div className="absolute top-0 left-0 -translate-x-full flex flex-col gap-1 p-1">
+            <div className="absolute top-0 right-0 translate-x-full flex flex-col gap-1 p-1">
               {selectedTask.parentId && (
                 <button
                   className="rounded border border-slate-300 bg-white px-1 text-[10px] hover:bg-slate-50"

--- a/docs/index.html
+++ b/docs/index.html
@@ -601,10 +601,10 @@ function PlannerApp(){
 
   return (
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
-      <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'360px 1fr',gap:'24px'}}>
+      <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <aside
-          className="sticky h-[82vh] overflow-y-auto border-r border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
-          style={{ top: headerHeight + 16 }}
+          className="sticky h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
+          style={{ top: headerHeight + 16, gridColumn:'2' }}
           aria-labelledby="notes-title"
         >
           <div id="notes-title" className="border-b border-slate-200 px-4 py-3 font-medium text-slate-700">{selectedTask ? selectedTask.title : 'Notes'}</div>
@@ -633,7 +633,7 @@ function PlannerApp(){
             )}
           </div>
         </aside>
-        <div className="flex flex-col">
+        <div className="flex flex-col" style={{gridColumn:'1'}}>
         {/* Top bar */}
         <div className="mb-4 flex items-center justify-between">
           <button
@@ -648,7 +648,7 @@ function PlannerApp(){
         {/* Gantt */}
         <div className="relative">
           {selectedTask && (
-            <div className="absolute top-0 left-0 -translate-x-full flex flex-col gap-1 p-1">
+            <div className="absolute top-0 right-0 translate-x-full flex flex-col gap-1 p-1">
               {selectedTask.parentId && (
                 <button
                   className="rounded border border-slate-300 bg-white px-1 text-[10px] hover:bg-slate-50"


### PR DESCRIPTION
## Summary
- position note sidebar on the right of the planner grid
- show task action buttons (trash, etc.) on the right side of the timeline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2445cdf8c8332a3c4c9daa811d655