### PR TITLE
Align notes panel with planner top

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -506,20 +506,11 @@ function PlannerApp(){
   }
 
   /* --------- Rendu --------- */
-  const headerRef = useRef(null);
-  const [headerHeight, setHeaderHeight] = useState(0);
-  useEffect(() => {
-    function updateHeight(){
-      if(headerRef.current) setHeaderHeight(headerRef.current.offsetHeight);
-    }
-    updateHeight();
-    window.addEventListener('resize', updateHeight);
-    return () => window.removeEventListener('resize', updateHeight);
-  }, []);
+  /* top offset for the notes panel matches container padding */
 
   const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
   const header = (
-    <div ref={headerRef} className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
+    <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
       <div style={{display:'grid', gridTemplateColumns:gridCols}}>
         {monthSegments.map((m,i)=>(
           <div key={`${m.label}-${i}`} className="flex items-center justify-center border-r border-slate-100 px-2 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600" style={{gridColumn:`span ${m.span} / span ${m.span}`}}>
@@ -604,7 +595,7 @@ function PlannerApp(){
       <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <aside
           className="sticky h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
-          style={{ top: headerHeight + 16, gridColumn:'2' }}
+          style={{ top: 16, gridColumn:'2' }}
           aria-labelledby="notes-title"
         >
           <div id="notes-title" className="border-b border-slate-200 px-4 py-3 font-medium text-slate-700">{selectedTask ? selectedTask.title : 'Notes'}</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -506,20 +506,11 @@ function PlannerApp(){
   }
 
   /* --------- Rendu --------- */
-  const headerRef = useRef(null);
-  const [headerHeight, setHeaderHeight] = useState(0);
-  useEffect(() => {
-    function updateHeight(){
-      if(headerRef.current) setHeaderHeight(headerRef.current.offsetHeight);
-    }
-    updateHeight();
-    window.addEventListener('resize', updateHeight);
-    return () => window.removeEventListener('resize', updateHeight);
-  }, []);
+  /* top offset for the notes panel matches container padding */
 
   const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
   const header = (
-    <div ref={headerRef} className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
+    <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
       <div style={{display:'grid', gridTemplateColumns:gridCols}}>
         {monthSegments.map((m,i)=>(
           <div key={`${m.label}-${i}`} className="flex items-center justify-center border-r border-slate-100 px-2 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600" style={{gridColumn:`span ${m.span} / span ${m.span}`}}>
@@ -604,7 +595,7 @@ function PlannerApp(){
       <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <aside
           className="sticky h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
-          style={{ top: headerHeight + 16, gridColumn:'2' }}
+          style={{ top: 16, gridColumn:'2' }}
           aria-labelledby="notes-title"
         >
           <div id="notes-title" className="border-b border-slate-200 px-4 py-3 font-medium text-slate-700">{selectedTask ? selectedTask.title : 'Notes'}</div>


### PR DESCRIPTION
## Summary
- align notes sidebar with the planner's top edge using a fixed offset
- remove header height measurement that was used for dynamic positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a246f6a0188332b1af8cfd8e24b5ab