### PR TITLE
fix: align notes panel with planner

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -506,7 +506,6 @@ function PlannerApp(){
   }
 
   /* --------- Rendu --------- */
-  /* top offset for the notes panel matches container padding */
 
   const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
   const header = (
@@ -594,8 +593,8 @@ function PlannerApp(){
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <aside
-          className="sticky h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
-          style={{ top: 16, gridColumn:'2' }}
+          className="h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
+          style={{ gridColumn:'2' }}
           aria-labelledby="notes-title"
         >
           <div id="notes-title" className="border-b border-slate-200 px-4 py-3 font-medium text-slate-700">{selectedTask ? selectedTask.title : 'Notes'}</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -506,7 +506,6 @@ function PlannerApp(){
   }
 
   /* --------- Rendu --------- */
-  /* top offset for the notes panel matches container padding */
 
   const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
   const header = (
@@ -594,8 +593,8 @@ function PlannerApp(){
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div className="mx-auto max-w-[1400px] px-4 py-4" style={{display:'grid',gridTemplateColumns:'1fr 360px',gap:'24px'}}>
         <aside
-          className="sticky h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
-          style={{ top: 16, gridColumn:'2' }}
+          className="h-[82vh] overflow-y-auto border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col"
+          style={{ gridColumn:'2' }}
           aria-labelledby="notes-title"
         >
           <div id="notes-title" className="border-b border-slate-200 px-4 py-3 font-medium text-slate-700">{selectedTask ? selectedTask.title : 'Notes'}</div>


### PR DESCRIPTION
## Summary
- align notes panel with the planner by removing sticky positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a249a5d8b88332958f81db85722459