### PR TITLE
Align header elements and update planning title

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Planning (sept. 2025 → fév. 2026)</title>
+    <title>planning D.U 17</title>
 
     <!-- Tailwind (CDN, pas de build) -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -29,9 +29,6 @@
     </style>
   </head>
   <body>
-    <header class="w-full flex justify-center py-4">
-      <img src="logo.png" alt="Logo" class="h-12 w-auto" />
-    </header>
     <div id="root"></div>
 
     <script type="text/babel" data-presets="env,react">
@@ -606,13 +603,14 @@ function PlannerApp(){
       >
         {/* Top bar sur 2 colonnes */}
         <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between">
+          <img src="logo.png" alt="Logo" className="h-12 w-auto" />
+          <h1 className="text-lg font-semibold tracking-tight">planning D.U 17</h1>
           <button
             onClick={() => setPanelOpen(v => !v)}
             className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50"
           >
             <span style={{fontSize:18}}>☰</span> Planificateur
           </button>
-          <h1 className="text-lg font-semibold tracking-tight">Planning (sept. 2025 → fév. 2026)</h1>
         </div>
 
         {/* Gantt gauche, ligne 2 */}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Planning (sept. 2025 → fév. 2026)</title>
+    <title>planning D.U 17</title>
 
     <!-- Tailwind (CDN, pas de build) -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -29,9 +29,6 @@
     </style>
   </head>
   <body>
-    <header class="w-full flex justify-center py-4">
-      <img src="logo.png" alt="Logo" class="h-12 w-auto" />
-    </header>
     <div id="root"></div>
 
     <script type="text/babel" data-presets="env,react">
@@ -606,13 +603,14 @@ function PlannerApp(){
       >
         {/* Top bar sur 2 colonnes */}
         <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between">
+          <img src="logo.png" alt="Logo" className="h-12 w-auto" />
+          <h1 className="text-lg font-semibold tracking-tight">planning D.U 17</h1>
           <button
             onClick={() => setPanelOpen(v => !v)}
             className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50"
           >
             <span style={{fontSize:18}}>☰</span> Planificateur
           </button>
-          <h1 className="text-lg font-semibold tracking-tight">Planning (sept. 2025 → fév. 2026)</h1>
         </div>
 
         {/* Gantt gauche, ligne 2 */}


### PR DESCRIPTION
## Summary
- Align logo, planning title and menu button on the same top bar
- Replace date-specific title with `planning D.U 17`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a25f526b3883329459246261a10ea4