### PR TITLE
Make planner grid width responsive

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -57,7 +57,7 @@ const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 /* ---------- Constantes UI / temps ---------- */
 const WEEK_STARTS_ON = 1;             // lundi
 const MS_DAY = 24*60*60*1000;
-const COL_W = 44;                     // largeur d’une semaine (px)
+const BASE_COL_W = 44;                // largeur par défaut d’une semaine (px)
 const ROW_H = 26;                     // hauteur d’une ligne (px)
 const ROW_GAP = 2;                    // petit padding vertical dans une ligne
 const SUB_ROW_H = 22;                 // hauteur d'une voie dans la sous-frise
@@ -110,19 +110,19 @@ function weekIndexOf(date, weeks){
   const idx = weeks.findIndex(w=>w.getTime()===s.getTime());
   return idx<0 ? weeks.length-1 : idx;
 }
-function taskGridInfo(task, weeks){
+function taskGridInfo(task, weeks, colW){
   const sIdx = weekIndexOf(new Date(task.startISO), weeks);
   const eIdx = weekIndexOf(new Date(task.endISO),   weeks);
   const span = Math.max(1, eIdx - sIdx + 1);
-  return { sIdx, eIdx, span, left: sIdx*COL_W, width: span*COL_W };
+  return { sIdx, eIdx, span, left: sIdx*colW, width: span*colW };
 }
 
 /* ---------- Packing (empilement) pour sous-tâches ----------
    Algorithme glouton : on trie par début, on pose dans la 1ère
    lane disponible (sans chevauchement).                        */
-function packLanes(children, weeks){
+function packLanes(children, weeks, colW){
   const items = children
-    .map(t => ({ t, ...taskGridInfo(t, weeks) }))
+    .map(t => ({ t, ...taskGridInfo(t, weeks, colW) }))
     .sort((a,b) => a.sIdx - b.sIdx || a.eIdx - b.eIdx);
 
   const lanes = []; // chaque lane = dernier eIdx
@@ -149,6 +149,7 @@ function fontPxFor(width, title){
 /* ---------- Composant ---------- */
 function PlannerApp(){
   const weeks = useMemo(()=>eachWeekOfInterval(TIMELINE_START, TIMELINE_END),[]);
+  const [colW, setColW] = useState(BASE_COL_W);
   const visibleWeeks = useMemo(
     ()=>weeks.filter(w=>!(w.getFullYear()===2026 && w.getMonth()===1)),
     [weeks]
@@ -257,7 +258,7 @@ function PlannerApp(){
       for (const p of rowTasks) {
         if (!p.expanded) continue;
         const children = tasks.filter(t => t.parentId === p.id);
-        const { lanesCount } = packLanes(children, visibleWeeks);
+        const { lanesCount } = packLanes(children, visibleWeeks, colW);
         rows.push({ type: 'sub', parentId: p.id, lanesCount });
       }
     }
@@ -272,6 +273,17 @@ function PlannerApp(){
   const containerRef = useRef(null);
   const scrollRef = useRef(null);
   const lastWasDblClickRef = useRef(false);
+
+  useEffect(()=>{
+    function updateWidth(){
+      if(!containerRef.current) return;
+      const width = containerRef.current.getBoundingClientRect().width;
+      setColW(width / visibleWeeks.length);
+    }
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
+  }, [visibleWeeks.length, notesOpen]);
 
   // recalcul des bounding boxes des sous-frises après rendu
   useEffect(()=>{
@@ -322,14 +334,14 @@ function PlannerApp(){
         d.node.style.transform = `translate3d(${tx}px,${ty}px,0)`;
       }
     }else if(d.type === 'left'){
-      const width = Math.max(COL_W, d.startWidth - d.dx);
+      const width = Math.max(colW, d.startWidth - d.dx);
       d.node.style.transform = `translate3d(${d.dx}px,0,0)`;
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
       if(width < BULLET_HIDE_W) d.node.classList.add('hide-bullet'); else d.node.classList.remove('hide-bullet');
     }else if(d.type === 'right'){
-      const width = Math.max(COL_W, d.startWidth + d.dx);
+      const width = Math.max(colW, d.startWidth + d.dx);
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
@@ -397,7 +409,7 @@ function PlannerApp(){
       setTasks(prev=>{
         const idx = prev.findIndex(x=>x.id===d.taskId); if(idx<0) return prev;
         const t0 = prev[idx];
-        const deltaWeeks = Math.round(d.dx / COL_W);
+        const deltaWeeks = Math.round(d.dx / colW);
         let ns = t0.startISO, ne = t0.endISO;
         if(d.type === 'move'){
           ns = addWeeksISO(t0.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
@@ -514,7 +526,7 @@ function PlannerApp(){
 
   /* --------- Rendu --------- */
 
-  const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
+  const gridCols = `repeat(${visibleWeeks.length}, ${colW}px)`;
   const header = (
     <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
       <div style={{display:'grid', gridTemplateColumns:gridCols}}>
@@ -535,7 +547,7 @@ function PlannerApp(){
   );
 
   function TaskBar({t, draggable=true, onToggle, isExpanded=false, rowHeight=ROW_H, gap=ROW_GAP}){
-    const g = taskGridInfo(t, visibleWeeks);
+    const g = taskGridInfo(t, visibleWeeks, colW);
     const isNarrow = g.width < BULLET_HIDE_W;
     const fontPx = fontPxFor(g.width, t.title);
     const barRef = useRef(null);
@@ -665,7 +677,7 @@ function PlannerApp(){
               const parent = tasks.find(t=>t.id===row.parentId);
               if(!parent) return null;
               const children = tasks.filter(t=>t.parentId===row.parentId);
-              const packed = packLanes(children, visibleWeeks);
+              const packed = packLanes(children, visibleWeeks, colW);
 
               return (
                 <div

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@ const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 /* ---------- Constantes UI / temps ---------- */
 const WEEK_STARTS_ON = 1;             // lundi
 const MS_DAY = 24*60*60*1000;
-const COL_W = 44;                     // largeur d’une semaine (px)
+const BASE_COL_W = 44;                // largeur par défaut d’une semaine (px)
 const ROW_H = 26;                     // hauteur d’une ligne (px)
 const ROW_GAP = 2;                    // petit padding vertical dans une ligne
 const SUB_ROW_H = 22;                 // hauteur d'une voie dans la sous-frise
@@ -110,19 +110,19 @@ function weekIndexOf(date, weeks){
   const idx = weeks.findIndex(w=>w.getTime()===s.getTime());
   return idx<0 ? weeks.length-1 : idx;
 }
-function taskGridInfo(task, weeks){
+function taskGridInfo(task, weeks, colW){
   const sIdx = weekIndexOf(new Date(task.startISO), weeks);
   const eIdx = weekIndexOf(new Date(task.endISO),   weeks);
   const span = Math.max(1, eIdx - sIdx + 1);
-  return { sIdx, eIdx, span, left: sIdx*COL_W, width: span*COL_W };
+  return { sIdx, eIdx, span, left: sIdx*colW, width: span*colW };
 }
 
 /* ---------- Packing (empilement) pour sous-tâches ----------
    Algorithme glouton : on trie par début, on pose dans la 1ère
    lane disponible (sans chevauchement).                        */
-function packLanes(children, weeks){
+function packLanes(children, weeks, colW){
   const items = children
-    .map(t => ({ t, ...taskGridInfo(t, weeks) }))
+    .map(t => ({ t, ...taskGridInfo(t, weeks, colW) }))
     .sort((a,b) => a.sIdx - b.sIdx || a.eIdx - b.eIdx);
 
   const lanes = []; // chaque lane = dernier eIdx
@@ -149,6 +149,7 @@ function fontPxFor(width, title){
 /* ---------- Composant ---------- */
 function PlannerApp(){
   const weeks = useMemo(()=>eachWeekOfInterval(TIMELINE_START, TIMELINE_END),[]);
+  const [colW, setColW] = useState(BASE_COL_W);
   const visibleWeeks = useMemo(
     ()=>weeks.filter(w=>!(w.getFullYear()===2026 && w.getMonth()===1)),
     [weeks]
@@ -258,7 +259,7 @@ function PlannerApp(){
       for (const p of rowTasks) {
         if (!p.expanded) continue;
         const children = tasks.filter(t => t.parentId === p.id);
-        const { lanesCount } = packLanes(children, visibleWeeks);
+        const { lanesCount } = packLanes(children, visibleWeeks, colW);
         rows.push({ type: 'sub', parentId: p.id, lanesCount });
       }
     }
@@ -273,6 +274,17 @@ function PlannerApp(){
   const containerRef = useRef(null);
   const scrollRef = useRef(null);
   const lastWasDblClickRef = useRef(false);
+
+  useEffect(()=>{
+    function updateWidth(){
+      if(!containerRef.current) return;
+      const width = containerRef.current.getBoundingClientRect().width;
+      setColW(width / visibleWeeks.length);
+    }
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
+  }, [visibleWeeks.length, notesOpen]);
 
   // recalcul des bounding boxes des sous-frises après rendu
   useEffect(()=>{
@@ -323,14 +335,14 @@ function PlannerApp(){
         d.node.style.transform = `translate3d(${tx}px,${ty}px,0)`;
       }
     }else if(d.type === 'left'){
-      const width = Math.max(COL_W, d.startWidth - d.dx);
+      const width = Math.max(colW, d.startWidth - d.dx);
       d.node.style.transform = `translate3d(${d.dx}px,0,0)`;
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
       if(width < BULLET_HIDE_W) d.node.classList.add('hide-bullet'); else d.node.classList.remove('hide-bullet');
     }else if(d.type === 'right'){
-      const width = Math.max(COL_W, d.startWidth + d.dx);
+      const width = Math.max(colW, d.startWidth + d.dx);
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
@@ -398,7 +410,7 @@ function PlannerApp(){
       setTasks(prev=>{
         const idx = prev.findIndex(x=>x.id===d.taskId); if(idx<0) return prev;
         const t0 = prev[idx];
-        const deltaWeeks = Math.round(d.dx / COL_W);
+        const deltaWeeks = Math.round(d.dx / colW);
         let ns = t0.startISO, ne = t0.endISO;
         if(d.type === 'move'){
           ns = addWeeksISO(t0.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
@@ -515,7 +527,7 @@ function PlannerApp(){
 
   /* --------- Rendu --------- */
 
-  const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
+  const gridCols = `repeat(${visibleWeeks.length}, ${colW}px)`;
   const header = (
     <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
       <div style={{display:'grid', gridTemplateColumns:gridCols}}>
@@ -536,7 +548,7 @@ function PlannerApp(){
   );
 
   function TaskBar({t, draggable=true, onToggle, isExpanded=false, rowHeight=ROW_H, gap=ROW_GAP}){
-    const g = taskGridInfo(t, visibleWeeks);
+    const g = taskGridInfo(t, visibleWeeks, colW);
     const isNarrow = g.width < BULLET_HIDE_W;
     const fontPx = fontPxFor(g.width, t.title);
     const barRef = useRef(null);
@@ -666,7 +678,7 @@ function PlannerApp(){
               const parent = tasks.find(t=>t.id===row.parentId);
               if(!parent) return null;
               const children = tasks.filter(t=>t.parentId===row.parentId);
-              const packed = packLanes(children, visibleWeeks);
+              const packed = packLanes(children, visibleWeeks, colW);
 
               return (
                 <div


### PR DESCRIPTION
## Summary
- compute week column width dynamically so the planner resizes with the page
- apply same responsive sizing to 404 page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26bb5833c83329c75505534475188