### PR TITLE
Fix notes panel reopen button not clickable

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -751,7 +751,7 @@ function PlannerApp(){
       {!notesOpen && (
         <button
           onClick={()=>setNotesOpen(true)}
-          className="fixed right-0 top-1/2 z-40 -translate-y-1/2 transform rounded-l-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow"
+          className="fixed right-0 top-1/2 z-50 pointer-events-auto -translate-y-1/2 transform rounded-l-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow"
         >
           Notes
         </button>


### PR DESCRIPTION
## Summary
- ensure the floating button that reopens the notes panel sits above other content and can receive clicks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a271cbf47883329cea0d7b7537d1e9