### PR TITLE
Fix notes panel layout and toggle button

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -612,11 +612,11 @@ function PlannerApp(){
   return (
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div
-        className="mx-auto max-w-full px-2 py-4 h-[82vh]"
+        className="mx-auto max-w-full px-2 py-4 h-[82vh] w-full"
         style={{ display:'grid', gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr', gridTemplateRows:'auto 1fr', gap:'24px' }}
       >
-        {/* Top bar sur 2 colonnes */}
-        <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="relative flex items-center justify-center px-3">
+        {/* Top bar uniquement sur la colonne principale */}
+        <div style={{ gridColumn:'1', gridRow:1 }} className="relative flex items-center justify-center px-3">
           <button
             onClick={() => setPanelOpen(v => !v)}
             className="absolute left-0 inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50"
@@ -708,13 +708,12 @@ function PlannerApp(){
             })}
           </div>
         </div>
-      </div>
 
-        {/* Notes droite, ligne 2 */}
+        {/* Notes droite */}
         {notesOpen && (
           <aside
           className="h-full border-l border-slate-200 bg-white rounded-2xl shadow-sm flex flex-col min-h-0"
-          style={{ gridColumn:'2', gridRow:2 }}
+          style={{ gridColumn:'2', gridRow:'1 / span 2' }}
           aria-labelledby="notes-title"
         >
           <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
@@ -751,7 +750,7 @@ function PlannerApp(){
       {!notesOpen && (
         <button
           onClick={()=>setNotesOpen(true)}
-          className="fixed right-0 top-1/2 z-50 pointer-events-auto -translate-y-1/2 transform rounded-l-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow"
+          className="fixed right-0 top-24 z-50 rounded-l-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow"
         >
           Notes
         </button>


### PR DESCRIPTION
## Summary
- Keep top bar centered by restricting it to main column and ensuring grid spans full width
- Move notes panel into grid's second column spanning the full height
- Reposition floating notes toggle button to top-right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2735cb4508332bfa062275a708ab0