### PR TITLE
Ensure planner fills width when notes panel is collapsed

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -601,7 +601,13 @@ function PlannerApp(){
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div
         className="mx-auto max-w-full px-2 py-4 h-[82vh]"
-        style={{ display:'grid', gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr', gridTemplateRows:'auto 1fr', gap:'24px' }}
+        style={{
+          display:'grid',
+          gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr',
+          gridTemplateRows:'auto 1fr',
+          columnGap: notesOpen ? '24px' : '0px',
+          rowGap:'24px'
+        }}
       >
         {/* Top bar sur 2 colonnes */}
         <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Remove remaining gap when notes sidebar is hidden so the Gantt grid uses full width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28166e2a48332b6f3ab0fb2fa4b72