### PR TITLE
Shorten planner timeline to end of January

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -75,7 +75,7 @@ function toISODate(d){ const y=d.getFullYear(); const m=String(d.getMonth()+1).p
 function addWeeksISO(iso,n,minD,maxD){ const d=new Date(iso); d.setDate(d.getDate()+7*n); return toISODate(clampDate(d,minD,maxD)); }
 function getISOWeek(date){ const d=new Date(Date.UTC(date.getFullYear(),date.getMonth(),date.getDate())); const dayNum=d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum); const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return Math.ceil(((d-yearStart)/MS_DAY+1)/7); }
 const TIMELINE_START = startOfWeek(new Date(2025,8,1));
-const TIMELINE_END   = endOfWeek(new Date(2026,1,28));
+const TIMELINE_END   = endOfWeek(new Date(2026,0,31));
 
 function eachWeekOfInterval(start,end){
   const weeks=[]; let cur=startOfWeek(start); const endW=startOfWeek(end);

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@ function toISODate(d){ const y=d.getFullYear(); const m=String(d.getMonth()+1).p
 function addWeeksISO(iso,n,minD,maxD){ const d=new Date(iso); d.setDate(d.getDate()+7*n); return toISODate(clampDate(d,minD,maxD)); }
 function getISOWeek(date){ const d=new Date(Date.UTC(date.getFullYear(),date.getMonth(),date.getDate())); const dayNum=d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum); const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return Math.ceil(((d-yearStart)/MS_DAY+1)/7); }
 const TIMELINE_START = startOfWeek(new Date(2025,8,1));
-const TIMELINE_END   = endOfWeek(new Date(2026,1,28));
+const TIMELINE_END   = endOfWeek(new Date(2026,0,31));
 
 function eachWeekOfInterval(start,end){
   const weeks=[]; let cur=startOfWeek(start); const endW=startOfWeek(end);


### PR DESCRIPTION
## Summary
- Stop timeline at January 2026 by setting `TIMELINE_END` to January 31
- Remove extra empty weeks on the right of the planner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab55fb72083328deb087f7dc17476