### PR TITLE
Shorten planner timeline and widen notes panel

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -75,7 +75,7 @@ function toISODate(d){ const y=d.getFullYear(); const m=String(d.getMonth()+1).p
 function addWeeksISO(iso,n,minD,maxD){ const d=new Date(iso); d.setDate(d.getDate()+7*n); return toISODate(clampDate(d,minD,maxD)); }
 function getISOWeek(date){ const d=new Date(Date.UTC(date.getFullYear(),date.getMonth(),date.getDate())); const dayNum=d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum); const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return Math.ceil(((d-yearStart)/MS_DAY+1)/7); }
 const TIMELINE_START = startOfWeek(new Date(2025,8,1));
-const TIMELINE_END   = endOfWeek(new Date(2026,1,28));
+const TIMELINE_END   = endOfWeek(new Date(2026,0,31));
 
 function eachWeekOfInterval(start,end){
   const weeks=[]; let cur=startOfWeek(start); const endW=startOfWeek(end);
@@ -600,7 +600,7 @@ function PlannerApp(){
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div
         className="mx-auto max-w-full px-2 py-4 h-[82vh]"
-        style={{ display:'grid', gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr', gridTemplateRows:'auto 1fr', gap:'24px' }}
+        style={{ display:'grid', gridTemplateColumns: notesOpen ? '1fr 432px' : '1fr', gridTemplateRows:'auto 1fr', gap:'24px' }}
       >
         {/* Top bar sur 2 colonnes */}
         <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between">
@@ -827,8 +827,8 @@ function PlannerApp(){
                     onClick={()=>{ const url=location.origin+location.pathname+location.search+'#s='+b64Encode(JSON.stringify({categories,tasks})); window.open(url,'_blank'); setPanelOpen(false); }}
                   >Nouveau (→ transfère)</button>
                 </div>
-                <div className="mt-4 flex flex-col items-center">
-                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-32 h-32" />
+                <div className="mt-8 flex flex-col items-center">
+                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-40 h-40" />
                   <p className="mt-2 text-sm text-slate-600">scan me</p>
                 </div>
               </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@ function toISODate(d){ const y=d.getFullYear(); const m=String(d.getMonth()+1).p
 function addWeeksISO(iso,n,minD,maxD){ const d=new Date(iso); d.setDate(d.getDate()+7*n); return toISODate(clampDate(d,minD,maxD)); }
 function getISOWeek(date){ const d=new Date(Date.UTC(date.getFullYear(),date.getMonth(),date.getDate())); const dayNum=d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum); const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return Math.ceil(((d-yearStart)/MS_DAY+1)/7); }
 const TIMELINE_START = startOfWeek(new Date(2025,8,1));
-const TIMELINE_END   = endOfWeek(new Date(2026,1,28));
+const TIMELINE_END   = endOfWeek(new Date(2026,0,31));
 
 function eachWeekOfInterval(start,end){
   const weeks=[]; let cur=startOfWeek(start); const endW=startOfWeek(end);
@@ -604,7 +604,7 @@ function PlannerApp(){
         className="mx-auto max-w-full px-2 py-4 h-[82vh]"
         style={{
           display:'grid',
-          gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr',
+          gridTemplateColumns: notesOpen ? '1fr 432px' : '1fr',
           gridTemplateRows:'auto 1fr',
           columnGap: notesOpen ? '24px' : '0px',
           rowGap:'24px'
@@ -835,8 +835,8 @@ function PlannerApp(){
                     onClick={()=>{ const url=location.origin+location.pathname+location.search+'#s='+b64Encode(JSON.stringify({categories,tasks})); window.open(url,'_blank'); setPanelOpen(false); }}
                   >Nouveau (→ transfère)</button>
                 </div>
-                <div className="mt-4 flex flex-col items-center">
-                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-32 h-32" />
+                <div className="mt-8 flex flex-col items-center">
+                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-40 h-40" />
                   <p className="mt-2 text-sm text-slate-600">scan me</p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Stop timeline at January 2026 by setting `TIMELINE_END` to January 31
- Remove extra empty weeks on the right of the planner
- Enlarge notes panel width by 20% for better readability
- Increase QR code size and add more spacing below action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab55fb72083328deb087f7dc17476