### PR TITLE
Shorten planner timeline, widen notes panel, and make week columns responsive

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -56,7 +56,7 @@ const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 /* ---------- Constantes UI / temps ---------- */
 const WEEK_STARTS_ON = 1;             // lundi
 const MS_DAY = 24*60*60*1000;
-const COL_W = 44;                     // largeur d’une semaine (px)
+const COL_W_MIN = 44;                 // largeur minimale d’une semaine (px)
 const ROW_H = 26;                     // hauteur d’une ligne (px)
 const ROW_GAP = 2;                    // petit padding vertical dans une ligne
 const SUB_ROW_H = 22;                 // hauteur d'une voie dans la sous-frise
@@ -75,7 +75,7 @@ function toISODate(d){ const y=d.getFullYear(); const m=String(d.getMonth()+1).p
 function addWeeksISO(iso,n,minD,maxD){ const d=new Date(iso); d.setDate(d.getDate()+7*n); return toISODate(clampDate(d,minD,maxD)); }
 function getISOWeek(date){ const d=new Date(Date.UTC(date.getFullYear(),date.getMonth(),date.getDate())); const dayNum=d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum); const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return Math.ceil(((d-yearStart)/MS_DAY+1)/7); }
 const TIMELINE_START = startOfWeek(new Date(2025,8,1));
-const TIMELINE_END   = endOfWeek(new Date(2026,1,28));
+const TIMELINE_END   = endOfWeek(new Date(2026,0,31));
 
 function eachWeekOfInterval(start,end){
   const weeks=[]; let cur=startOfWeek(start); const endW=startOfWeek(end);
@@ -109,19 +109,19 @@ function weekIndexOf(date, weeks){
   const idx = weeks.findIndex(w=>w.getTime()===s.getTime());
   return idx<0 ? weeks.length-1 : idx;
 }
-function taskGridInfo(task, weeks){
+function taskGridInfo(task, weeks, colW){
   const sIdx = weekIndexOf(new Date(task.startISO), weeks);
   const eIdx = weekIndexOf(new Date(task.endISO),   weeks);
   const span = Math.max(1, eIdx - sIdx + 1);
-  return { sIdx, eIdx, span, left: sIdx*COL_W, width: span*COL_W };
+  return { sIdx, eIdx, span, left: sIdx*colW, width: span*colW };
 }
 
 /* ---------- Packing (empilement) pour sous-tâches ----------
    Algorithme glouton : on trie par début, on pose dans la 1ère
    lane disponible (sans chevauchement).                        */
-function packLanes(children, weeks){
+function packLanes(children, weeks, colW){
   const items = children
-    .map(t => ({ t, ...taskGridInfo(t, weeks) }))
+    .map(t => ({ t, ...taskGridInfo(t, weeks, colW) }))
     .sort((a,b) => a.sIdx - b.sIdx || a.eIdx - b.eIdx);
 
   const lanes = []; // chaque lane = dernier eIdx
@@ -183,6 +183,7 @@ function PlannerApp(){
   );
   const [panelOpen,setPanelOpen] = useState(false);
   const [notesOpen,setNotesOpen] = useState(true);
+  const [colW,setColW] = useState(COL_W_MIN);
 
   // synchro Supabase (inchangé)
   useEffect(()=>{
@@ -257,13 +258,13 @@ function PlannerApp(){
       for (const p of rowTasks) {
         if (!p.expanded) continue;
         const children = tasks.filter(t => t.parentId === p.id);
-        const { lanesCount } = packLanes(children, visibleWeeks);
+        const { lanesCount } = packLanes(children, visibleWeeks, colW);
         rows.push({ type: 'sub', parentId: p.id, lanesCount });
       }
     }
 
     return rows;
-  }, [filteredTop, tasks, visibleWeeks]);
+  }, [filteredTop, tasks, visibleWeeks, colW]);
 
   /* --------- DnD (déplacement & drop dans sous-frise) --------- */
   const dragRef = useRef(null);          // {taskId,type,startX,startY,dx,dy,...}
@@ -272,6 +273,23 @@ function PlannerApp(){
   const containerRef = useRef(null);
   const scrollRef = useRef(null);
   const lastWasDblClickRef = useRef(false);
+
+  useEffect(()=>{
+    const update = () => {
+      const el = containerRef.current;
+      if(!el) return;
+      const w = el.clientWidth;
+      setColW(Math.max(COL_W_MIN, Math.floor(w / visibleWeeks.length)));
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    if(containerRef.current) ro.observe(containerRef.current);
+    window.addEventListener('resize', update);
+    return ()=>{
+      ro.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, [visibleWeeks.length]);
 
   // recalcul des bounding boxes des sous-frises après rendu
   useEffect(()=>{
@@ -322,14 +340,14 @@ function PlannerApp(){
         d.node.style.transform = `translate3d(${tx}px,${ty}px,0)`;
       }
     }else if(d.type === 'left'){
-      const width = Math.max(COL_W, d.startWidth - d.dx);
+      const width = Math.max(colW, d.startWidth - d.dx);
       d.node.style.transform = `translate3d(${d.dx}px,0,0)`;
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
       if(width < BULLET_HIDE_W) d.node.classList.add('hide-bullet'); else d.node.classList.remove('hide-bullet');
     }else if(d.type === 'right'){
-      const width = Math.max(COL_W, d.startWidth + d.dx);
+      const width = Math.max(colW, d.startWidth + d.dx);
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
@@ -397,7 +415,7 @@ function PlannerApp(){
       setTasks(prev=>{
         const idx = prev.findIndex(x=>x.id===d.taskId); if(idx<0) return prev;
         const t0 = prev[idx];
-        const deltaWeeks = Math.round(d.dx / COL_W);
+        const deltaWeeks = Math.round(d.dx / colW);
         let ns = t0.startISO, ne = t0.endISO;
         if(d.type === 'move'){
           ns = addWeeksISO(t0.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
@@ -514,7 +532,7 @@ function PlannerApp(){
 
   /* --------- Rendu --------- */
 
-  const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
+  const gridCols = `repeat(${visibleWeeks.length}, ${colW}px)`;
   const header = (
     <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
       <div style={{display:'grid', gridTemplateColumns:gridCols}}>
@@ -535,7 +553,7 @@ function PlannerApp(){
   );
 
   function TaskBar({t, draggable=true, onToggle, isExpanded=false, rowHeight=ROW_H, gap=ROW_GAP}){
-    const g = taskGridInfo(t, visibleWeeks);
+    const g = taskGridInfo(t, visibleWeeks, colW);
     const isNarrow = g.width < BULLET_HIDE_W;
     const fontPx = fontPxFor(g.width, t.title);
     const barRef = useRef(null);
@@ -600,7 +618,7 @@ function PlannerApp(){
     <div className="min-h-screen w-full overflow-x-hidden bg-gradient-to-br from-slate-50 to-slate-100 text-slate-900">
       <div
         className="mx-auto max-w-full px-2 py-4 h-[82vh]"
-        style={{ display:'grid', gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr', gridTemplateRows:'auto 1fr', gap:'24px' }}
+        style={{ display:'grid', gridTemplateColumns: notesOpen ? '1fr 432px' : '1fr', gridTemplateRows:'auto 1fr', gap:'24px' }}
       >
         {/* Top bar sur 2 colonnes */}
         <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between">
@@ -665,7 +683,7 @@ function PlannerApp(){
               const parent = tasks.find(t=>t.id===row.parentId);
               if(!parent) return null;
               const children = tasks.filter(t=>t.parentId===row.parentId);
-              const packed = packLanes(children, visibleWeeks);
+              const packed = packLanes(children, visibleWeeks, colW);
 
               return (
                 <div
@@ -827,8 +845,8 @@ function PlannerApp(){
                     onClick={()=>{ const url=location.origin+location.pathname+location.search+'#s='+b64Encode(JSON.stringify({categories,tasks})); window.open(url,'_blank'); setPanelOpen(false); }}
                   >Nouveau (→ transfère)</button>
                 </div>
-                <div className="mt-4 flex flex-col items-center">
-                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-32 h-32" />
+                <div className="mt-8 flex flex-col items-center">
+                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-40 h-40" />
                   <p className="mt-2 text-sm text-slate-600">scan me</p>
                 </div>
               </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@ const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 /* ---------- Constantes UI / temps ---------- */
 const WEEK_STARTS_ON = 1;             // lundi
 const MS_DAY = 24*60*60*1000;
-const COL_W = 44;                     // largeur d’une semaine (px)
+const COL_W_MIN = 44;                 // largeur minimale d’une semaine (px)
 const ROW_H = 26;                     // hauteur d’une ligne (px)
 const ROW_GAP = 2;                    // petit padding vertical dans une ligne
 const SUB_ROW_H = 22;                 // hauteur d'une voie dans la sous-frise
@@ -75,7 +75,7 @@ function toISODate(d){ const y=d.getFullYear(); const m=String(d.getMonth()+1).p
 function addWeeksISO(iso,n,minD,maxD){ const d=new Date(iso); d.setDate(d.getDate()+7*n); return toISODate(clampDate(d,minD,maxD)); }
 function getISOWeek(date){ const d=new Date(Date.UTC(date.getFullYear(),date.getMonth(),date.getDate())); const dayNum=d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum); const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1)); return Math.ceil(((d-yearStart)/MS_DAY+1)/7); }
 const TIMELINE_START = startOfWeek(new Date(2025,8,1));
-const TIMELINE_END   = endOfWeek(new Date(2026,1,28));
+const TIMELINE_END   = endOfWeek(new Date(2026,0,31));
 
 function eachWeekOfInterval(start,end){
   const weeks=[]; let cur=startOfWeek(start); const endW=startOfWeek(end);
@@ -109,19 +109,19 @@ function weekIndexOf(date, weeks){
   const idx = weeks.findIndex(w=>w.getTime()===s.getTime());
   return idx<0 ? weeks.length-1 : idx;
 }
-function taskGridInfo(task, weeks){
+function taskGridInfo(task, weeks, colW){
   const sIdx = weekIndexOf(new Date(task.startISO), weeks);
   const eIdx = weekIndexOf(new Date(task.endISO),   weeks);
   const span = Math.max(1, eIdx - sIdx + 1);
-  return { sIdx, eIdx, span, left: sIdx*COL_W, width: span*COL_W };
+  return { sIdx, eIdx, span, left: sIdx*colW, width: span*colW };
 }
 
 /* ---------- Packing (empilement) pour sous-tâches ----------
    Algorithme glouton : on trie par début, on pose dans la 1ère
    lane disponible (sans chevauchement).                        */
-function packLanes(children, weeks){
+function packLanes(children, weeks, colW){
   const items = children
-    .map(t => ({ t, ...taskGridInfo(t, weeks) }))
+    .map(t => ({ t, ...taskGridInfo(t, weeks, colW) }))
     .sort((a,b) => a.sIdx - b.sIdx || a.eIdx - b.eIdx);
 
   const lanes = []; // chaque lane = dernier eIdx
@@ -183,6 +183,7 @@ function PlannerApp(){
   );
   const [panelOpen,setPanelOpen] = useState(false);
   const [notesOpen,setNotesOpen] = useState(true);
+  const [colW,setColW] = useState(COL_W_MIN);
 
   // synchro Supabase (inchangé)
   useEffect(()=>{
@@ -257,13 +258,13 @@ function PlannerApp(){
       for (const p of rowTasks) {
         if (!p.expanded) continue;
         const children = tasks.filter(t => t.parentId === p.id);
-        const { lanesCount } = packLanes(children, visibleWeeks);
+        const { lanesCount } = packLanes(children, visibleWeeks, colW);
         rows.push({ type: 'sub', parentId: p.id, lanesCount });
       }
     }
 
     return rows;
-  }, [filteredTop, tasks, visibleWeeks]);
+  }, [filteredTop, tasks, visibleWeeks, colW]);
 
   /* --------- DnD (déplacement & drop dans sous-frise) --------- */
   const dragRef = useRef(null);          // {taskId,type,startX,startY,dx,dy,...}
@@ -272,6 +273,23 @@ function PlannerApp(){
   const containerRef = useRef(null);
   const scrollRef = useRef(null);
   const lastWasDblClickRef = useRef(false);
+
+  useEffect(()=>{
+    const update = () => {
+      const el = containerRef.current;
+      if(!el) return;
+      const w = el.clientWidth;
+      setColW(Math.max(COL_W_MIN, Math.floor(w / visibleWeeks.length)));
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    if(containerRef.current) ro.observe(containerRef.current);
+    window.addEventListener('resize', update);
+    return ()=>{
+      ro.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, [visibleWeeks.length]);
 
   // recalcul des bounding boxes des sous-frises après rendu
   useEffect(()=>{
@@ -323,14 +341,14 @@ function PlannerApp(){
         d.node.style.transform = `translate3d(${tx}px,${ty}px,0)`;
       }
     }else if(d.type === 'left'){
-      const width = Math.max(COL_W, d.startWidth - d.dx);
+      const width = Math.max(colW, d.startWidth - d.dx);
       d.node.style.transform = `translate3d(${d.dx}px,0,0)`;
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
       if(width < BULLET_HIDE_W) d.node.classList.add('hide-bullet'); else d.node.classList.remove('hide-bullet');
     }else if(d.type === 'right'){
-      const width = Math.max(COL_W, d.startWidth + d.dx);
+      const width = Math.max(colW, d.startWidth + d.dx);
       d.node.style.width = width + 'px';
       const font = fontPxFor(width, d.title);
       d.node.style.setProperty('--task-font', font + 'px');
@@ -399,7 +417,7 @@ function PlannerApp(){
       setTasks(prev=>{
         const idx = prev.findIndex(x=>x.id===d.taskId); if(idx<0) return prev;
         const t0 = prev[idx];
-        const deltaWeeks = Math.round(d.dx / COL_W);
+        const deltaWeeks = Math.round(d.dx / colW);
         let ns = t0.startISO, ne = t0.endISO;
         if(d.type === 'move'){
           ns = addWeeksISO(t0.startISO, deltaWeeks, TIMELINE_START, TIMELINE_END);
@@ -516,7 +534,7 @@ function PlannerApp(){
 
   /* --------- Rendu --------- */
 
-  const gridCols = `repeat(${visibleWeeks.length}, ${COL_W}px)`;
+  const gridCols = `repeat(${visibleWeeks.length}, ${colW}px)`;
   const header = (
     <div className="sticky top-0 z-10 border-b border-slate-200 bg-white/90">
       <div style={{display:'grid', gridTemplateColumns:gridCols}}>
@@ -537,7 +555,7 @@ function PlannerApp(){
   );
 
   function TaskBar({t, draggable=true, onToggle, isExpanded=false, rowHeight=ROW_H, gap=ROW_GAP}){
-    const g = taskGridInfo(t, visibleWeeks);
+    const g = taskGridInfo(t, visibleWeeks, colW);
     const isNarrow = g.width < BULLET_HIDE_W;
     const fontPx = fontPxFor(g.width, t.title);
     const barRef = useRef(null);
@@ -604,7 +622,7 @@ function PlannerApp(){
         className="mx-auto max-w-full px-2 py-4 h-[82vh]"
         style={{
           display:'grid',
-          gridTemplateColumns: notesOpen ? '1fr 360px' : '1fr',
+          gridTemplateColumns: notesOpen ? '1fr 432px' : '1fr',
           gridTemplateRows:'auto 1fr',
           columnGap: notesOpen ? '24px' : '0px',
           rowGap:'24px'
@@ -673,7 +691,7 @@ function PlannerApp(){
               const parent = tasks.find(t=>t.id===row.parentId);
               if(!parent) return null;
               const children = tasks.filter(t=>t.parentId===row.parentId);
-              const packed = packLanes(children, visibleWeeks);
+              const packed = packLanes(children, visibleWeeks, colW);
 
               return (
                 <div
@@ -835,8 +853,8 @@ function PlannerApp(){
                     onClick={()=>{ const url=location.origin+location.pathname+location.search+'#s='+b64Encode(JSON.stringify({categories,tasks})); window.open(url,'_blank'); setPanelOpen(false); }}
                   >Nouveau (→ transfère)</button>
                 </div>
-                <div className="mt-4 flex flex-col items-center">
-                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-32 h-32" />
+                <div className="mt-8 flex flex-col items-center">
+                  <img src="scan-me.png" alt="QR code pour accéder à l'outil" className="w-40 h-40" />
                   <p className="mt-2 text-sm text-slate-600">scan me</p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Stop timeline at January 2026 by setting `TIMELINE_END` to January 31
- Remove extra empty weeks on the right of the planner
- Enlarge notes panel width by 20% for better readability
- Increase QR code size and add more spacing below action buttons
- Make week columns responsive to fill wider screens without exceeding viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab55fb72083328deb087f7dc17476