### PR TITLE
Use ID_KEY constant in setIdentity

### DIFF
--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -195,7 +195,7 @@ const CFG = {
     async setIdentity({ pseudo, color }) {
       if (pseudo) identity.pseudo = pseudo;
       if (color)  identity.color  = color;
-      localStorage.setItem("planner_identity", JSON.stringify(identity));
+      localStorage.setItem(ID_KEY, JSON.stringify(identity));
       // republie l’état presence
       await channel.track({ pseudo: identity.pseudo, color: identity.color });
     }


### PR DESCRIPTION
## Summary
- use `ID_KEY` constant for localStorage in realtime setIdentity

## Testing
- `node --check docs/realtime.js`
- `rg '"planner_identity"' -n`

------
https://chatgpt.com/codex/tasks/task_e_68bca2d661bc8332a42e0323cc4cc431