### PR TITLE
refactor: share identity constants

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -30,12 +30,14 @@
       body.is-dragging { cursor:grabbing; user-select:none; }
     </style>
   </head>
-  <body>
-     <div id="root"></div>
-    <script type="text/babel" data-presets="env,react">
+    <body>
+       <div id="root"></div>
+      <script type="text/babel" data-presets="env,react" data-type="module">
 /* ===========================================================
    GANTT collaboratif (presence + broadcast + BDD realtime)
    =========================================================== */
+
+import { PALETTE, NAMES, ID_KEY } from "./identity.js";
 
 const { useEffect, useMemo, useRef, useState } = React;
 
@@ -54,9 +56,6 @@ if (window.supabase && typeof window.supabase.createClient === "function") {
 }
 
 /* ---------- Identité (pseudo + couleur) ---------- */
-const PALETTE = ["#2563eb","#16a34a","#ea580c","#9333ea","#0ea5e9","#ef4444","#22c55e","#f59e0b","#64748b","#d946ef","#14b8a6","#a16207"];
-const NAMES = ["Arthur","Lancelot","Perceval","Karadoc","Bohort","Léodagan","Séli","Guenièvre","Merlin","Mevanwi","Yvain","Gauvain"];
-const ID_KEY = "planner_identity_v2";
 let IDENTITY = null;
 try {
   IDENTITY = JSON.parse(localStorage.getItem(ID_KEY) || "null");

--- a/docs/identity.js
+++ b/docs/identity.js
@@ -1,0 +1,3 @@
+export const PALETTE = ["#2563eb","#16a34a","#ea580c","#9333ea","#0ea5e9","#ef4444","#22c55e","#f59e0b","#64748b","#d946ef","#14b8a6","#a16207"];
+export const NAMES = ["Arthur","Lancelot","Perceval","Karadoc","Bohort","Léodagan","Séli","Guenièvre","Merlin","Mevanwi","Yvain","Gauvain"];
+export const ID_KEY = "planner_identity_v2";

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,12 +30,14 @@
       body.is-dragging { cursor:grabbing; user-select:none; }
     </style>
   </head>
-  <body>
-     <div id="root"></div>
-    <script type="text/babel" data-presets="env,react">
+    <body>
+       <div id="root"></div>
+      <script type="text/babel" data-presets="env,react" data-type="module">
 /* ===========================================================
    GANTT collaboratif (presence + broadcast + BDD realtime)
    =========================================================== */
+
+import { PALETTE, NAMES, ID_KEY } from "./identity.js";
 
 const { useEffect, useMemo, useRef, useState } = React;
 
@@ -54,9 +56,6 @@ if (window.supabase && typeof window.supabase.createClient === "function") {
 }
 
 /* ---------- Identité (pseudo + couleur) ---------- */
-const PALETTE = ["#2563eb","#16a34a","#ea580c","#9333ea","#0ea5e9","#ef4444","#22c55e","#f59e0b","#64748b","#d946ef","#14b8a6","#a16207"];
-const NAMES = ["Arthur","Lancelot","Perceval","Karadoc","Bohort","Léodagan","Séli","Guenièvre","Merlin","Mevanwi","Yvain","Gauvain"];
-const ID_KEY = "planner_identity_v2";
 let IDENTITY = null;
 try {
   IDENTITY = JSON.parse(localStorage.getItem(ID_KEY) || "null");

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -5,6 +5,8 @@
    - Expose une API globale window.RT pour brancher votre UI.
 */
 
+import { PALETTE, NAMES, ID_KEY } from "./identity.js";
+
 (() => {
   // ─────────────────────────────────────────────────────────────────────────────
   //  CONFIG À RENSEIGNER
@@ -93,9 +95,6 @@ const CFG = {
   const sb = window.supabase.createClient(CFG.url, CFG.anonKey);
 
   // Identité “anonyme” locale (mémoire navigateur)
-  const PALETTE = ["#2563eb","#16a34a","#ea580c","#9333ea","#0ea5e9","#ef4444","#22c55e","#f59e0b","#64748b","#d946ef","#14b8a6","#a16207"];
-  const NAMES = ["Arthur","Lancelot","Perceval","Karadoc","Bohort","Léodagan","Séli","Guenièvre","Merlin","Mevanwi","Yvain","Gauvain"];
-  const ID_KEY = "planner_identity_v2";
   let identity = null;
   try {
     identity = JSON.parse(localStorage.getItem(ID_KEY) || "null");


### PR DESCRIPTION
## Summary
- create `docs/identity.js` exporting identity constants
- reuse shared identity constants in docs pages and realtime plugin

## Testing
- `node --check docs/identity.js`
- `node --check docs/realtime.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bca3c999148332a3483db00ea90cfc