### PR TITLE
fix: load identity constants without imports

### DIFF
--- a/docs/identity.js
+++ b/docs/identity.js
@@ -1,3 +1,15 @@
-export const PALETTE = ["#2563eb","#16a34a","#ea580c","#9333ea","#0ea5e9","#ef4444","#22c55e","#f59e0b","#64748b","#d946ef","#14b8a6","#a16207"];
-export const NAMES = ["Arthur","Lancelot","Perceval","Karadoc","Bohort","Léodagan","Séli","Guenièvre","Merlin","Mevanwi","Yvain","Gauvain"];
-export const ID_KEY = "planner_identity_v2";
+// Global identity constants used by the planner UI
+window.Identity = {
+  PALETTE: [
+    "#2563eb","#16a34a","#ea580c","#9333ea","#0ea5e9",
+    "#ef4444","#22c55e","#f59e0b","#64748b","#d946ef",
+    "#14b8a6","#a16207"
+  ],
+  NAMES: [
+    "Arthur","Lancelot","Perceval","Karadoc","Bohort",
+    "Léodagan","Séli","Guenièvre","Merlin","Mevanwi",
+    "Yvain","Gauvain"
+  ],
+  ID_KEY: "planner_identity_v2"
+};
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,10 @@
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 
+    <!-- Local helpers -->
+    <script src="identity.js"></script>
+    <script src="realtime.js"></script>
+
     <!-- Markdown parser -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
@@ -32,12 +36,12 @@
   </head>
     <body>
        <div id="root"></div>
-      <script type="text/babel" data-presets="env,react" data-type="module">
+      <script type="text/babel" data-presets="env,react">
 /* ===========================================================
    GANTT collaboratif (presence + broadcast + BDD realtime)
    =========================================================== */
 
-import { PALETTE, NAMES, ID_KEY } from "./identity.js";
+const { PALETTE, NAMES, ID_KEY } = window.Identity;
 
 const { useEffect, useMemo, useRef, useState } = React;
 

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -5,7 +5,7 @@
    - Expose une API globale window.RT pour brancher votre UI.
 */
 
-import { PALETTE, NAMES, ID_KEY } from "./identity.js";
+const { PALETTE, NAMES, ID_KEY } = window.Identity;
 
 (() => {
   // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- expose identity constants as global object
- avoid in-browser module imports and load realtime script directly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bca5c861308332bae7f6f0ec982877