### PR TITLE
fix: avoid global redeclaration of NAMES

### DIFF
--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -5,9 +5,8 @@
    - Expose une API globale window.RT pour brancher votre UI.
 */
 
-const { PALETTE, NAMES, ID_KEY } = window.Identity;
-
 (() => {
+  const { PALETTE, NAMES, ID_KEY } = window.Identity;
   // ─────────────────────────────────────────────────────────────────────────────
   //  CONFIG À RENSEIGNER
   // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- scope identity constants inside realtime helper to prevent NAMES redeclaration

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bcce71fbe08332bd8642f16d3af846