### PR TITLE
Reposition presence list above logo and remove legacy badge

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -18,7 +18,6 @@
 
     <!-- Local helpers -->
     <script src="identity.js"></script>
-    <script src="realtime.js"></script>
 
     <!-- Markdown parser -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -759,7 +758,7 @@ function PlannerApp(){
         }}
       >
         {/* Top bar sur 2 colonnes */}
-        <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between gap-3">
+        <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-start justify-between gap-3">
           <button
             onClick={() => setPanelOpen(v => !v)}
             className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50"
@@ -767,25 +766,19 @@ function PlannerApp(){
             <span style={{fontSize:18}}>☰</span> Planificateur
           </button>
 
-          {/* Présence (utilisateurs en ligne) */}
-          <div className="flex items-center gap-2 flex-1 justify-center">
-            {presence.map(p=>(
-              <span key={p.id}
-                className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
-                style={{ borderColor:p.color, color:p.color }}
-                title={p.pseudo}
-              >
-                <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor:p.color }}></span>
-                {p.pseudo}
-              </span>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-500" title="Votre identité">
-              {IDENTITY.pseudo}
-            </span>
-            <span className="inline-block h-3 w-3 rounded-full" style={{backgroundColor:IDENTITY.color}} title={IDENTITY.color}></span>
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-2">
+              {presence.map(p=>(
+                <span key={p.id}
+                  className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+                  style={{ borderColor:p.color, color:p.color }}
+                  title={p.pseudo}
+                >
+                  <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor:p.color }}></span>
+                  {p.pseudo}
+                </span>
+              ))}
+            </div>
             <img src="logo.png" alt="Logo" className="h-12 w-auto" />
           </div>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,6 @@
 
     <!-- Local helpers -->
     <script src="identity.js"></script>
-    <script src="realtime.js"></script>
 
     <!-- Markdown parser -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -759,7 +758,7 @@ function PlannerApp(){
         }}
       >
         {/* Top bar sur 2 colonnes */}
-        <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-center justify-between gap-3">
+        <div style={{ gridColumn:'1 / -1', gridRow:1 }} className="flex items-start justify-between gap-3">
           <button
             onClick={() => setPanelOpen(v => !v)}
             className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm hover:bg-slate-50"
@@ -767,25 +766,19 @@ function PlannerApp(){
             <span style={{fontSize:18}}>☰</span> Planificateur
           </button>
 
-          {/* Présence (utilisateurs en ligne) */}
-          <div className="flex items-center gap-2 flex-1 justify-center">
-            {presence.map(p=>(
-              <span key={p.id}
-                className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
-                style={{ borderColor:p.color, color:p.color }}
-                title={p.pseudo}
-              >
-                <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor:p.color }}></span>
-                {p.pseudo}
-              </span>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-500" title="Votre identité">
-              {IDENTITY.pseudo}
-            </span>
-            <span className="inline-block h-3 w-3 rounded-full" style={{backgroundColor:IDENTITY.color}} title={IDENTITY.color}></span>
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-2">
+              {presence.map(p=>(
+                <span key={p.id}
+                  className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+                  style={{ borderColor:p.color, color:p.color }}
+                  title={p.pseudo}
+                >
+                  <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor:p.color }}></span>
+                  {p.pseudo}
+                </span>
+              ))}
+            </div>
             <img src="logo.png" alt="Logo" className="h-12 w-auto" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove legacy realtime.js badge that duplicated presence
- stack online user list above the logo in the top bar

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd174498483328467daee17c50372