### PR TITLE
Show pseudonyms before logo in top bar

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -766,7 +766,7 @@ function PlannerApp(){
             <span style={{fontSize:18}}>☰</span> Planificateur
           </button>
 
-          <div className="flex flex-col items-end gap-1">
+          <div className="flex items-center gap-2">
             <div className="flex items-center gap-2">
               {presence.map(p=>(
                 <span key={p.id}

--- a/docs/index.html
+++ b/docs/index.html
@@ -766,7 +766,7 @@ function PlannerApp(){
             <span style={{fontSize:18}}>☰</span> Planificateur
           </button>
 
-          <div className="flex flex-col items-end gap-1">
+          <div className="flex items-center gap-2">
             <div className="flex items-center gap-2">
               {presence.map(p=>(
                 <span key={p.id}


### PR DESCRIPTION
## Summary
- Align presence list and logo horizontally in planner UI.
- Display user pseudonyms to the left of the logo on both main and 404 pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd435a0e88332bbaa1e1124ad7488