### PR TITLE
feat: show local pseudonym by default

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -209,7 +209,10 @@ function PlannerApp(){
   const [colW,setColW] = useState(COL_W_MIN);
 
   /* ---------- Collaboration: Presence + Broadcast ---------- */
-  const [presence, setPresence] = useState([]);           // [{id,pseudo,color}]
+  // Show local pseudonym even if realtime channel is unavailable
+  const [presence, setPresence] = useState([
+    { id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color }
+  ]); // [{id,pseudo,color}]
   const chanRef = useRef(null);                           // realtime channel
   const ghostRef = useRef(new Map());                    // taskId -> {from,deltaWeeks,color}
 
@@ -224,6 +227,9 @@ function PlannerApp(){
       for (const [id, arr] of Object.entries(st)) {
         const last = arr[arr.length-1];
         if (last) flat.push({ id, pseudo:last.pseudo, color:last.color });
+      }
+      if (!flat.some(p => p.id === IDENTITY.id)) {
+        flat.push({ id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color });
       }
       setPresence(flat);
     });

--- a/docs/index.html
+++ b/docs/index.html
@@ -209,7 +209,10 @@ function PlannerApp(){
   const [colW,setColW] = useState(COL_W_MIN);
 
   /* ---------- Collaboration: Presence + Broadcast ---------- */
-  const [presence, setPresence] = useState([]);           // [{id,pseudo,color}]
+  // Start with the local identity so the pseudonym is visible even without realtime
+  const [presence, setPresence] = useState([
+    { id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color }
+  ]); // [{id,pseudo,color}]
   const chanRef = useRef(null);                           // realtime channel
   const ghostRef = useRef(new Map());                    // taskId -> {from,deltaWeeks,color}
 
@@ -224,6 +227,9 @@ function PlannerApp(){
       for (const [id, arr] of Object.entries(st)) {
         const last = arr[arr.length-1];
         if (last) flat.push({ id, pseudo:last.pseudo, color:last.color });
+      }
+      if (!flat.some(p => p.id === IDENTITY.id)) {
+        flat.push({ id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color });
       }
       setPresence(flat);
     });


### PR DESCRIPTION
## Summary
- display local user's pseudonym beside logo without requiring realtime
- ensure 404 view also shows local pseudonym by default
- keep local pseudonym when merging realtime presence so connected users are visible simultaneously

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd602d6ec8332901f4157e65226cc