### PR TITLE
Fix presence sync to show all active user pseudonyms

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -224,9 +224,10 @@ function PlannerApp(){
     ch.on("presence", { event: "sync" }, () => {
       const st = ch.presenceState();
       const flat = [];
-      for (const [id, arr] of Object.entries(st)) {
-        const last = arr[arr.length-1];
-        if (last) flat.push({ id, pseudo:last.pseudo, color:last.color });
+      for (const [id, info] of Object.entries(st)) {
+        const metas = Array.isArray(info) ? info : (info && info.metas) || [];
+        const last = metas[metas.length - 1];
+        if (last) flat.push({ id, pseudo: last.pseudo, color: last.color });
       }
       if (!flat.some(p => p.id === IDENTITY.id)) {
         flat.push({ id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color });

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -117,12 +117,13 @@ const CFG = {
   channel
     // Liste des personnes connectées (sync)
     .on("presence", { event: "sync" }, () => {
-      // presenceState() => { key: [states...] }
+      // presenceState() => { key: { metas: [...] } }
       const state = channel.presenceState();
       const flat = [];
-      for (const [id, arr] of Object.entries(state)) {
+      for (const [id, info] of Object.entries(state)) {
+        const metas = Array.isArray(info) ? info : (info && info.metas) || [];
         // on garde la dernière version
-        const st = arr[arr.length - 1];
+        const st = metas[metas.length - 1];
         if (st) flat.push({ id, pseudo: st.pseudo, color: st.color });
       }
       hooks.onPresence(flat);


### PR DESCRIPTION
## Summary
- Parse `presenceState` metas in realtime hooks to collect all active users
- Display every connected user's pseudonym in planner UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdb86d75c833285492bf24d37d52d