### PR TITLE
Ensure presence list updates on join and leave events

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -221,7 +221,7 @@ function PlannerApp(){
     if (!supabase) return;
     const ch = supabase.channel(CFG.room, { config: { presence: { key: IDENTITY.id } } });
 
-    ch.on("presence", { event: "sync" }, () => {
+    const refreshPresence = () => {
       const st = ch.presenceState();
       const flat = [];
       for (const [id, info] of Object.entries(st)) {
@@ -233,7 +233,12 @@ function PlannerApp(){
         flat.push({ id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color });
       }
       setPresence(flat);
-    });
+    };
+
+    ch
+      .on("presence", { event: "sync" }, refreshPresence)
+      .on("presence", { event: "join" }, refreshPresence)
+      .on("presence", { event: "leave" }, refreshPresence);
 
     ch.on("broadcast", { event: "drag" }, ({ payload }) => {
       const { t, taskId, from, deltaWeeks=0, by, color } = payload || {};


### PR DESCRIPTION
## Summary
- Refresh presence list on sync, join, and leave events to show all connected users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bce480ec2c8332b1b58704f056bb98