### PR TITLE
Fix realtime presence display

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -223,11 +223,13 @@ function PlannerApp(){
 
     ch.on("presence", { event: "sync" }, () => {
       const st = ch.presenceState();
-      const flat = [];
-      for (const [id, arr] of Object.entries(st)) {
-        const last = arr[arr.length-1];
-        if (last) flat.push({ id, pseudo:last.pseudo, color:last.color });
-      }
+      const entries = st instanceof Map ? Array.from(st.entries()) : Object.entries(st);
+      const flat = entries
+        .map(([id, arr]) => {
+          const last = Array.isArray(arr) ? arr[arr.length - 1] : (arr && arr.metas ? arr.metas[arr.metas.length - 1] : null);
+          return last ? { id, pseudo: last.pseudo, color: last.color } : null;
+        })
+        .filter(Boolean);
       if (!flat.some(p => p.id === IDENTITY.id)) {
         flat.push({ id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color });
       }

--- a/docs/index.html
+++ b/docs/index.html
@@ -223,12 +223,14 @@ function PlannerApp(){
 
     const refreshPresence = () => {
       const st = ch.presenceState();
-      const flat = [];
-      for (const [id, info] of Object.entries(st)) {
-        const metas = Array.isArray(info) ? info : (info && info.metas) || [];
-        const last = metas[metas.length - 1];
-        if (last) flat.push({ id, pseudo: last.pseudo, color: last.color });
-      }
+      const entries = st instanceof Map ? Array.from(st.entries()) : Object.entries(st);
+      const flat = entries
+        .map(([id, info]) => {
+          const metas = Array.isArray(info) ? info : (info && info.metas) || [];
+          const last = metas[metas.length - 1];
+          return last ? { id, pseudo: last.pseudo, color: last.color } : null;
+        })
+        .filter(Boolean);
       if (!flat.some(p => p.id === IDENTITY.id)) {
         flat.push({ id: IDENTITY.id, pseudo: IDENTITY.pseudo, color: IDENTITY.color });
       }

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -117,13 +117,16 @@ const CFG = {
   const refreshPresence = () => {
     // presenceState() => { key: { metas: [...] } }
     const state = channel.presenceState();
-    const flat = [];
-    for (const [id, info] of Object.entries(state)) {
-      const metas = Array.isArray(info) ? info : (info && info.metas) || [];
-      // on garde la dernière version
-      const st = metas[metas.length - 1];
-      if (st) flat.push({ id, pseudo: st.pseudo, color: st.color });
-    }
+    const entries = state instanceof Map
+      ? Array.from(state.entries())
+      : Object.entries(state);
+    const flat = entries
+      .map(([id, info]) => {
+        const metas = Array.isArray(info) ? info : (info && info.metas) || [];
+        const st = metas[metas.length - 1];
+        return st ? { id, pseudo: st.pseudo, color: st.color } : null;
+      })
+      .filter(Boolean);
     hooks.onPresence(flat);
   };
 


### PR DESCRIPTION
## Summary
- handle Supabase presence state returned as Map or object
- render all connected users without overwriting previous ones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcec4110f483329f621953df743bb6