### PR TITLE
Ensure Supabase channel effect only runs on mount

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -268,7 +268,7 @@ function PlannerApp(){
 
     chanRef.current = ch;
     return () => { try { supabase.removeChannel(ch); } catch {} };
-  }, [colW]);
+  }, []);
 
   /* ---------- Realtime BDD sur planner_state ---------- */
   useEffect(()=>{

--- a/docs/index.html
+++ b/docs/index.html
@@ -274,7 +274,7 @@ function PlannerApp(){
 
     chanRef.current = ch;
     return () => { try { supabase.removeChannel(ch); } catch {} };
-  }, [colW]);
+  }, []);
 
   /* ---------- Realtime BDD sur planner_state ---------- */
   useEffect(()=>{


### PR DESCRIPTION
## Summary
- run presence/broadcast Supabase channel effect only once on mount
- retain channel cleanup via `removeChannel`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd563eaad883328009948a7a598088