### PR TITLE
Fix Supabase presence parsing for v1/v2

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -223,7 +223,8 @@ function PlannerApp(){
 
     ch.on("presence", { event: "sync" }, () => {
       const st = ch.presenceState();
-      const flat = Array.from(st.entries())
+      const entries = st instanceof Map ? Array.from(st.entries()) : Object.entries(st);
+      const flat = entries
         .map(([id, metas]) => {
           const last = metas[metas.length - 1];
           return last ? { id, pseudo: last.pseudo, color: last.color } : null;

--- a/docs/index.html
+++ b/docs/index.html
@@ -223,7 +223,8 @@ function PlannerApp(){
 
     const refreshPresence = () => {
       const st = ch.presenceState();
-      const flat = Array.from(st.entries())
+      const entries = st instanceof Map ? Array.from(st.entries()) : Object.entries(st);
+      const flat = entries
         .map(([id, metas]) => {
           const last = metas[metas.length - 1];
           return last ? { id, pseudo: last.pseudo, color: last.color } : null;

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -128,9 +128,10 @@ const CFG = {
   });
 
   const refreshPresence = () => {
-    // presenceState() => Map(key => [metas])
+    // presenceState() => Map(key => [metas]) ou objet simple
     const state = channel.presenceState();
-    const flat = Array.from(state.entries())
+    const entries = state instanceof Map ? Array.from(state.entries()) : Object.entries(state);
+    const flat = entries
       .map(([id, metas]) => {
         const st = metas[metas.length - 1];
         return st ? { id, pseudo: st.pseudo, color: st.color } : null;


### PR DESCRIPTION
## Summary
- Support both Map and object returns from `presenceState()` in realtime helpers
- Ensure Supabase CDN script path stays on a single line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd54ae498483329c27c39769563e17