### PR TITLE
Harden realtime: add websocket fallback + self-hosted y-websocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,56 @@ The planner helps students stay organized by laying out tasks week by week. It d
 
 - **React 18** renders the interactive timeline interface directly in the browser.
 - **Tailwind CSS** provides utility classes for quick styling and layout.
-- **Yjs + y-webrtc** provide a backendless P2P realtime layer for shared state and live presence.
+- **Yjs** provides CRDT shared state.
+- **y-webrtc** enables P2P realtime (default mode).
+- **y-websocket** can be enabled for production-grade signaling/relay.
 - **Babel** transpiles JSX on the fly so that the app can be served as a simple static page.
 
 All client-side dependencies are loaded from CDNs, allowing the planner to run without a build step.
+
+## Realtime Modes
+
+The app now supports two runtime modes:
+
+- `webrtc` (default): uses y-webrtc + signaling servers.
+- `websocket`: uses y-websocket against your own backend endpoint.
+
+### Configure by URL
+
+- WebRTC mode (default):
+  - `?rt=webrtc`
+  - optional custom signaling: `?rt=webrtc&signaling=wss://your-signal.example.com`
+- WebSocket mode:
+  - `?rt=websocket&ws=wss://your-yws.example.com`
+
+You can also persist values in localStorage:
+
+- `planner_rt_mode`: `webrtc` or `websocket`
+- `planner_signaling_url`: comma-separated signaling URLs
+- `planner_ws_endpoint`: websocket endpoint URL
+
+## Minimal backend for production (y-websocket)
+
+A tiny Node server is provided in `infra/y-websocket`.
+
+```bash
+cd infra/y-websocket
+npm install
+npm start
+```
+
+Environment variables:
+
+- `PORT` (default `1234`)
+- `HOST` (default `0.0.0.0`)
+
+Health endpoint:
+
+- `GET /healthz`
+
+Typical deployment target: Render / Railway / Fly.io free tier, then point the static app to:
+
+- `https://<user>.github.io/planner/?rt=websocket&ws=wss://<your-backend-domain>`
 
 ## Usage
 
@@ -21,5 +67,4 @@ All client-side dependencies are loaded from CDNs, allowing the planner to run w
 2. Add categories and tasks to build the timeline.
 3. Drag tasks across the weeks to adjust scheduling. Notes can be attached to tasks for additional context.
 
-Because the app is entirely static, it can be hosted on any static file server (such as GitHub Pages) by serving the `docs/` directory.
-
+Because the app is static, it can be hosted on any static file server (such as GitHub Pages) by serving the `docs/` directory.

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,13 +13,15 @@
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
-    <!-- Yjs + y-webrtc (ESM, exposés sur window pour le script React/Babel) -->
+    <!-- Yjs + providers temps réel (ESM, exposés sur window pour le script React/Babel) -->
     <script type="module">
       import * as Y from "https://esm.sh/yjs";
       import { WebrtcProvider } from "https://esm.sh/y-webrtc";
+      import { WebsocketProvider } from "https://esm.sh/y-websocket";
 
       window.Y = Y;
       window.WebrtcProvider = WebrtcProvider;
+      window.WebsocketProvider = WebsocketProvider;
       window.dispatchEvent(new Event("yjsReady"));
     </script>
 
@@ -57,15 +59,29 @@ const { PALETTE, NAMES: IDENTITY_NAMES, ID_KEY } = window.Identity;
 
 const { useEffect, useMemo, useRef, useState } = React;
 
-/* ---------- Yjs / WebRTC (P2P sans backend) ---------- */
-const YJS_SIGNALING = ["wss://signaling.yjs.dev"];
+/* ---------- Yjs Realtime (WebRTC ou WebSocket managé) ---------- */
+const REALTIME = {
+  roomPrefix: "planner_",
+  mode: (new URLSearchParams(location.search).get("rt") || localStorage.getItem("planner_rt_mode") || "webrtc").toLowerCase(),
+  webrtc: {
+    signaling: (
+      new URLSearchParams(location.search).get("signaling")
+      || localStorage.getItem("planner_signaling_url")
+      || "wss://signaling.yjs.dev"
+    ).split(",").map(s => s.trim()).filter(Boolean)
+  },
+  websocket: {
+    endpoint: new URLSearchParams(location.search).get("ws") || localStorage.getItem("planner_ws_endpoint") || ""
+  }
+};
+
 const YJS_ICE_SERVERS = [
   { urls: "stun:stun.l.google.com:19302" },
   { urls: "stun:global.stun.twilio.com:3478" }
 ];
 
 const yjsRuntime = {
-  ready: !!(window.Y && window.WebrtcProvider),
+  ready: !!(window.Y && window.WebrtcProvider && window.WebsocketProvider),
   waiters: []
 };
 window.addEventListener("yjsReady", () => {
@@ -76,6 +92,24 @@ window.addEventListener("yjsReady", () => {
 function onYjsReady(cb){
   if(yjsRuntime.ready) cb();
   else yjsRuntime.waiters.push(cb);
+}
+
+function createRealtimeProvider(planRoom, ydoc){
+  const room = `${REALTIME.roomPrefix}${planRoom}`;
+
+  if (REALTIME.mode === "websocket") {
+    const WebsocketProvider = window.WebsocketProvider;
+    const endpoint = REALTIME.websocket.endpoint;
+    if (!WebsocketProvider || !endpoint) return null;
+    return new WebsocketProvider(endpoint, room, ydoc, { connect: true });
+  }
+
+  const WebrtcProvider = window.WebrtcProvider;
+  if (!WebrtcProvider) return null;
+  return new WebrtcProvider(room, ydoc, {
+    signaling: REALTIME.webrtc.signaling,
+    peerOpts: { config: { iceServers: YJS_ICE_SERVERS } }
+  });
 }
 /* ---------- Identité (pseudo + couleur) ---------- */
 let IDENTITY = null;
@@ -326,14 +360,14 @@ function PlannerApp(){
     let dispose = () => {};
     onYjsReady(() => {
       const Y = window.Y;
-      const WebrtcProvider = window.WebrtcProvider;
-      if (!Y || !WebrtcProvider) return;
+      if (!Y) return;
 
       const ydoc = new Y.Doc();
-      const provider = new WebrtcProvider(`planner_${activePlan.room}`, ydoc, {
-        signaling: YJS_SIGNALING,
-        peerOpts: { config: { iceServers: YJS_ICE_SERVERS } }
-      });
+      const provider = createRealtimeProvider(activePlan.room, ydoc);
+      if (!provider) {
+        console.error("[realtime] Provider indisponible. Vérifier planner_rt_mode/planner_ws_endpoint.");
+        return;
+      }
       const ystate = ydoc.getMap('planner_state');
 
       providerRef.current = provider;

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -1,5 +1,5 @@
 /* docs/realtime.js
-   Realtime P2P pour planner statique (Yjs + y-webrtc, sans backend).
+   Realtime pour planner statique (Yjs + providers).
    - État persistant partagé via Y.Map ("planner_state").
    - Presence + événements éphémères via awareness.
    - Expose une API globale window.RT pour brancher une UI non-React.
@@ -21,9 +21,15 @@
   };
   const { PALETTE, NAMES, ID_KEY } = window.Identity || DEFAULT_IDENTITY;
 
+  const q = new URLSearchParams(location.search);
   const CFG = {
     room: "planner_room_main",
-    signaling: ["wss://signaling.yjs.dev"],
+    mode: (q.get("rt") || localStorage.getItem("planner_rt_mode") || "webrtc").toLowerCase(),
+    signaling: (q.get("signaling") || localStorage.getItem("planner_signaling_url") || "wss://signaling.yjs.dev")
+      .split(",")
+      .map(s => s.trim())
+      .filter(Boolean),
+    websocketEndpoint: q.get("ws") || localStorage.getItem("planner_ws_endpoint") || "",
     iceServers: [
       { urls: "stun:stun.l.google.com:19302" },
       { urls: "stun:global.stun.twilio.com:3478" }
@@ -48,8 +54,8 @@
     }
   };
 
-  if (!window.Y || !window.WebrtcProvider) {
-    console.error("[RT] Yjs/y-webrtc non chargés.");
+  if (!window.Y || (!window.WebrtcProvider && !window.WebsocketProvider)) {
+    console.error("[RT] Yjs/providers non chargés.");
     return;
   }
 
@@ -64,10 +70,25 @@
   }
 
   const ydoc = new window.Y.Doc();
-  const provider = new window.WebrtcProvider(CFG.room, ydoc, {
-    signaling: CFG.signaling,
-    peerOpts: { config: { iceServers: CFG.iceServers } }
-  });
+  let provider = null;
+
+  if (CFG.mode === "websocket") {
+    if (!window.WebsocketProvider || !CFG.websocketEndpoint) {
+      console.error("[RT] Mode websocket choisi mais endpoint/ws provider manquant.");
+      return;
+    }
+    provider = new window.WebsocketProvider(CFG.websocketEndpoint, CFG.room, ydoc, { connect: true });
+  } else {
+    if (!window.WebrtcProvider) {
+      console.error("[RT] WebrtcProvider indisponible.");
+      return;
+    }
+    provider = new window.WebrtcProvider(CFG.room, ydoc, {
+      signaling: CFG.signaling,
+      peerOpts: { config: { iceServers: CFG.iceServers } }
+    });
+  }
+
   const stateMap = ydoc.getMap("planner_state");
 
   const emitState = () => hooks.onState({

--- a/infra/y-websocket/package.json
+++ b/infra/y-websocket/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "planner-y-websocket-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "ws": "^8.18.0",
+    "y-websocket": "^2.1.0"
+  }
+}

--- a/infra/y-websocket/server.js
+++ b/infra/y-websocket/server.js
@@ -1,0 +1,26 @@
+import http from 'node:http'
+import { WebSocketServer } from 'ws'
+import { setupWSConnection } from 'y-websocket/bin/utils.js'
+
+const HOST = process.env.HOST || '0.0.0.0'
+const PORT = Number(process.env.PORT || 1234)
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/healthz') {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ ok: true }))
+    return
+  }
+  res.writeHead(200, { 'content-type': 'text/plain' })
+  res.end('planner y-websocket signaling is running')
+})
+
+const wss = new WebSocketServer({ server })
+
+wss.on('connection', (conn, req) => {
+  setupWSConnection(conn, req, { gc: true })
+})
+
+server.listen(PORT, HOST, () => {
+  console.log(`[y-websocket] listening on http://${HOST}:${PORT}`)
+})


### PR DESCRIPTION
### Motivation
- The current 100% client + public signaling setup with `y-webrtc` is brittle in production because public signaling endpoints are rate-limited/unreliable and there's no TURN fallback on GitHub Pages. 
- Provide a low-cost, predictable signaling/relay path so the static site can run reliable realtime collaboration in production.

### Description
- Add dual realtime runtime support to the static app so it can run in `webrtc` (default) or `websocket` mode, configurable via URL params (`?rt=webrtc|websocket`, `?signaling=...`, `?ws=...`) or localStorage keys (`planner_rt_mode`, `planner_signaling_url`, `planner_ws_endpoint`). (files: `docs/index.html`, `docs/realtime.js`)
- Expose and import `WebsocketProvider` (from `y-websocket`) alongside `WebrtcProvider` and centralize instantiation behind `createRealtimeProvider(planRoom, ydoc)` so the app selects the correct provider at runtime. (file: `docs/index.html`)
- Add a minimal self-hostable `y-websocket` backend scaffold using Node + `ws` + `y-websocket` with a health endpoint at `/healthz` for easy deployment to Render/Railway/Fly.io. (files: `infra/y-websocket/server.js`, `infra/y-websocket/package.json`)
- Update `README.md` with configuration and deployment guidance for switching to `websocket` mode and deploying the provided backend. (file: `README.md`)

### Testing
- Executed a syntax check on the backend script with `node --check infra/y-websocket/server.js`, which completed successfully. 
- Performed static/manual verification of the runtime wiring in `docs/index.html` and `docs/realtime.js` to ensure `WebsocketProvider` is imported and the `createRealtimeProvider` factory is used; no runtime errors observed in this review step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b37bc692483328d785a284f9cbafb)