### PR TITLE
Harden Yjs realtime with multi-signaling and zero-config WebSocket fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ All client-side dependencies are loaded from CDNs, allowing the planner to run w
 
 The app now supports two runtime modes:
 
-- `webrtc` (default): uses y-webrtc + signaling servers.
-- `websocket`: uses y-websocket against your own backend endpoint.
+- `webrtc` (default): uses y-webrtc + multiple public signaling servers.
+- `websocket`: uses y-websocket against your own backend endpoint (or a public fallback endpoint).
 
 ### Configure by URL
 
 - WebRTC mode (default):
   - `?rt=webrtc`
-  - optional custom signaling: `?rt=webrtc&signaling=wss://your-signal.example.com`
+  - optional custom signaling: `?rt=webrtc&signaling=wss://signal-1.example.com,wss://signal-2.example.com`
+  - optional automatic fallback to WebSocket if no peer appears: `?fallback=websocket&fallbackDelayMs=7000&publicWs=wss://demos.yjs.dev`
 - WebSocket mode:
   - `?rt=websocket&ws=wss://your-yws.example.com`
 
@@ -37,6 +38,9 @@ You can also persist values in localStorage:
 - `planner_rt_mode`: `webrtc` or `websocket`
 - `planner_signaling_url`: comma-separated signaling URLs
 - `planner_ws_endpoint`: websocket endpoint URL
+- `planner_public_ws_endpoint`: public fallback websocket endpoint (default `wss://demos.yjs.dev`)
+- `planner_rt_fallback`: `websocket` to auto-fallback from WebRTC
+- `planner_rt_fallback_delay`: delay in ms before fallback check
 
 ## Minimal backend for production (y-websocket)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,18 +60,28 @@ const { PALETTE, NAMES: IDENTITY_NAMES, ID_KEY } = window.Identity;
 const { useEffect, useMemo, useRef, useState } = React;
 
 /* ---------- Yjs Realtime (WebRTC ou WebSocket managé) ---------- */
+const q = new URLSearchParams(location.search);
 const REALTIME = {
   roomPrefix: "planner_",
-  mode: (new URLSearchParams(location.search).get("rt") || localStorage.getItem("planner_rt_mode") || "webrtc").toLowerCase(),
+  mode: (q.get("rt") || localStorage.getItem("planner_rt_mode") || "webrtc").toLowerCase(),
   webrtc: {
     signaling: (
-      new URLSearchParams(location.search).get("signaling")
+      q.get("signaling")
       || localStorage.getItem("planner_signaling_url")
-      || "wss://signaling.yjs.dev"
+      || [
+        "wss://signaling.yjs.dev",
+        "wss://y-webrtc-signaling-eu.herokuapp.com",
+        "wss://y-webrtc-signaling-us.herokuapp.com"
+      ].join(",")
     ).split(",").map(s => s.trim()).filter(Boolean)
   },
   websocket: {
-    endpoint: new URLSearchParams(location.search).get("ws") || localStorage.getItem("planner_ws_endpoint") || ""
+    endpoint: q.get("ws") || localStorage.getItem("planner_ws_endpoint") || "",
+    publicFallback: q.get("publicWs") || localStorage.getItem("planner_public_ws_endpoint") || "wss://demos.yjs.dev"
+  },
+  fallback: {
+    mode: (q.get("fallback") || localStorage.getItem("planner_rt_fallback") || "websocket").toLowerCase(),
+    delayMs: Number(q.get("fallbackDelayMs") || localStorage.getItem("planner_rt_fallback_delay") || 7000)
   }
 };
 
@@ -94,12 +104,17 @@ function onYjsReady(cb){
   else yjsRuntime.waiters.push(cb);
 }
 
-function createRealtimeProvider(planRoom, ydoc){
-  const room = `${REALTIME.roomPrefix}${planRoom}`;
+function resolveWebsocketEndpoint(){
+  return REALTIME.websocket.endpoint || REALTIME.websocket.publicFallback;
+}
 
-  if (REALTIME.mode === "websocket") {
+function createRealtimeProvider(planRoom, ydoc, forceMode=null){
+  const room = `${REALTIME.roomPrefix}${planRoom}`;
+  const mode = forceMode || REALTIME.mode;
+
+  if (mode === "websocket") {
     const WebsocketProvider = window.WebsocketProvider;
-    const endpoint = REALTIME.websocket.endpoint;
+    const endpoint = resolveWebsocketEndpoint();
     if (!WebsocketProvider || !endpoint) return null;
     return new WebsocketProvider(endpoint, room, ydoc, { connect: true });
   }
@@ -108,6 +123,7 @@ function createRealtimeProvider(planRoom, ydoc){
   if (!WebrtcProvider) return null;
   return new WebrtcProvider(room, ydoc, {
     signaling: REALTIME.webrtc.signaling,
+    maxConns: 35,
     peerOpts: { config: { iceServers: YJS_ICE_SERVERS } }
   });
 }
@@ -363,7 +379,7 @@ function PlannerApp(){
       if (!Y) return;
 
       const ydoc = new Y.Doc();
-      const provider = createRealtimeProvider(activePlan.room, ydoc);
+      let provider = createRealtimeProvider(activePlan.room, ydoc);
       if (!provider) {
         console.error("[realtime] Provider indisponible. Vérifier planner_rt_mode/planner_ws_endpoint.");
         return;
@@ -386,7 +402,7 @@ function PlannerApp(){
       ystate.observe(syncFromMap);
       syncFromMap();
 
-      const awareness = provider.awareness;
+      let awareness = provider.awareness;
       awareness.setLocalStateField('user', {
         id: IDENTITY.id,
         pseudo: IDENTITY.pseudo,
@@ -425,7 +441,33 @@ function PlannerApp(){
       awareness.on('change', onAwareness);
       onAwareness();
 
+      const fallbackTimer = (
+        REALTIME.mode === 'webrtc' && REALTIME.fallback.mode === 'websocket'
+      ) ? setTimeout(() => {
+        const peerCount = Array.from(awareness.getStates().values()).filter(st => st.user).length;
+        if (peerCount > 1) return;
+
+        const wsProvider = createRealtimeProvider(activePlan.room, ydoc, 'websocket');
+        if (!wsProvider) return;
+
+        console.warn(`[realtime] Aucun pair WebRTC détecté après ${REALTIME.fallback.delayMs}ms: bascule en WebSocket public.`);
+        awareness.off('change', onAwareness);
+        provider.destroy();
+
+        providerRef.current = wsProvider;
+        provider = wsProvider;
+        awareness = wsProvider.awareness;
+        awareness.setLocalStateField('user', {
+          id: IDENTITY.id,
+          pseudo: IDENTITY.pseudo,
+          color: IDENTITY.color
+        });
+        awareness.on('change', onAwareness);
+        onAwareness();
+      }, Math.max(2000, REALTIME.fallback.delayMs || 7000)) : null;
+
       dispose = () => {
+        if (fallbackTimer) clearTimeout(fallbackTimer);
         awareness.setLocalStateField('dragEvent', null);
         awareness.off('change', onAwareness);
         ystate.unobserve(syncFromMap);

--- a/docs/realtime.js
+++ b/docs/realtime.js
@@ -29,7 +29,10 @@
       .split(",")
       .map(s => s.trim())
       .filter(Boolean),
+    fallbackMode: (q.get("fallback") || localStorage.getItem("planner_rt_fallback") || "websocket").toLowerCase(),
+    fallbackDelayMs: Number(q.get("fallbackDelayMs") || localStorage.getItem("planner_rt_fallback_delay") || 7000),
     websocketEndpoint: q.get("ws") || localStorage.getItem("planner_ws_endpoint") || "",
+    publicWebsocketFallback: q.get("publicWs") || localStorage.getItem("planner_public_ws_endpoint") || "wss://demos.yjs.dev",
     iceServers: [
       { urls: "stun:stun.l.google.com:19302" },
       { urls: "stun:global.stun.twilio.com:3478" }
@@ -72,12 +75,15 @@
   const ydoc = new window.Y.Doc();
   let provider = null;
 
+  const resolveWsEndpoint = () => CFG.websocketEndpoint || CFG.publicWebsocketFallback;
+
   if (CFG.mode === "websocket") {
-    if (!window.WebsocketProvider || !CFG.websocketEndpoint) {
+    const endpoint = resolveWsEndpoint();
+    if (!window.WebsocketProvider || !endpoint) {
       console.error("[RT] Mode websocket choisi mais endpoint/ws provider manquant.");
       return;
     }
-    provider = new window.WebsocketProvider(CFG.websocketEndpoint, CFG.room, ydoc, { connect: true });
+    provider = new window.WebsocketProvider(endpoint, CFG.room, ydoc, { connect: true });
   } else {
     if (!window.WebrtcProvider) {
       console.error("[RT] WebrtcProvider indisponible.");
@@ -91,12 +97,42 @@
 
   const stateMap = ydoc.getMap("planner_state");
 
+  const enableFallbackToWebsocket = () => {
+    if (
+      CFG.mode !== "webrtc"
+      || CFG.fallbackMode !== "websocket"
+      || !window.WebsocketProvider
+      || !provider?.awareness
+    ) return;
+
+    const fallbackTimer = setTimeout(() => {
+      const peers = Array.from(provider.awareness.getStates().values()).filter(s => s?.user).length;
+      if (peers > 1) return;
+
+      const endpoint = resolveWsEndpoint();
+      if (!endpoint) return;
+
+      console.warn(`[RT] Aucun pair WebRTC détecté après ${CFG.fallbackDelayMs}ms, bascule en WebSocket: ${endpoint}`);
+
+      awareness.off("change", onAwareness);
+      provider.destroy();
+      provider = new window.WebsocketProvider(endpoint, CFG.room, ydoc, { connect: true });
+
+      awareness = provider.awareness;
+      awareness.setLocalStateField("user", identity);
+      awareness.on("change", onAwareness);
+      onAwareness();
+    }, Math.max(2000, CFG.fallbackDelayMs || 7000));
+
+    return () => clearTimeout(fallbackTimer);
+  };
+
   const emitState = () => hooks.onState({
     blocks: stateMap.get("blocks") || []
   });
   stateMap.observe(emitState);
 
-  const awareness = provider.awareness;
+  let awareness = provider.awareness;
   awareness.setLocalStateField("user", identity);
   const onAwareness = () => {
     const states = Array.from(awareness.getStates().values());
@@ -104,6 +140,7 @@
     states.forEach((s) => { if (s.dragEvent && s.dragEvent.from !== identity.id) hooks.onLiveDrag(s.dragEvent); });
   };
   awareness.on("change", onAwareness);
+  const disableFallbackTimer = enableFallbackToWebsocket();
 
   window.RT = {
     getIdentity() { return { ...identity }; },
@@ -134,4 +171,8 @@
       awareness.setLocalStateField("dragEvent", null);
     }
   };
+
+  window.addEventListener("beforeunload", () => {
+    if (typeof disableFallbackTimer === "function") disableFallbackTimer();
+  });
 })();


### PR DESCRIPTION
### Motivation
- Cross-device WebRTC sessions were failing in production due to a single public signaling endpoint and lack of a resilient fallback, causing empty sessions across browsers and devices. 
- The goal is to improve real-world reliability while keeping a strict "zero account / zero self-host" constraint.

### Description
- Add multiple public WebRTC signaling endpoints by default and allow custom comma-separated `signaling` URLs via query string or `planner_signaling_url` in localStorage. (files: `docs/index.html`, `docs/realtime.js`).
- Implement an automatic fallback path from WebRTC to a public WebSocket relay when no remote peer appears after a configurable timeout, using a public fallback endpoint defaulting to `wss://demos.yjs.dev`. The fallback is configurable via `fallback`, `fallbackDelayMs`, and `publicWs` query params or corresponding localStorage keys. (files: `docs/index.html`, `docs/realtime.js`).
- Provide a robust provider switch that rebinds `awareness` and preserves presence/drag behavior after switching from `WebrtcProvider` to `WebsocketProvider`. (files: `docs/index.html`, `docs/realtime.js`).
- Unify runtime parameter parsing and expose new URL/localStorage knobs: `fallback`, `fallbackDelayMs`, `publicWs` / `planner_public_ws_endpoint`, `planner_rt_fallback`, `planner_rt_fallback_delay`. (files: `docs/index.html`, `docs/realtime.js`, `README.md`).
- Minor WebRTC tuning: increase `maxConns` for `WebrtcProvider` and expose a public websocket resolver for zero-config fallback. (files: `docs/index.html`).

### Testing
- Static JS sanity check of `docs/realtime.js` with `node --check` succeeded. (status: passed)
- Repository diff check (`git diff --check`) passed with no whitespace/syntax issues. (status: passed)
- Extracted browser script contains JSX and failed `node --check` as expected because it requires Babel transpilation, so this failure is expected and not indicative of the runtime changes. (status: expected failure)
- No runtime browser automated tests were run; changes are limited to client-side runtime configuration and were validated by static checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3b45f3b08332890a0cc1730376d4)